### PR TITLE
feat: add Google Calendar artifacts processing and pull jobs for #9

### DIFF
--- a/apps/api/prisma/migrations/20260505165330_meetings_v1/migration.sql
+++ b/apps/api/prisma/migrations/20260505165330_meetings_v1/migration.sql
@@ -1,0 +1,184 @@
+-- AlterTable
+ALTER TABLE "Company" ADD COLUMN     "domains" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- AlterTable
+ALTER TABLE "Note" ADD COLUMN     "meetingId" INTEGER,
+ADD COLUMN     "source" TEXT NOT NULL DEFAULT 'manual';
+
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "autoExtracted" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "customerCommitment" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "sourceActionItemText" TEXT,
+ADD COLUMN     "sourceMeetingId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "GoogleCalendarSync" (
+    "googleAccountId" INTEGER NOT NULL,
+    "eventsSyncToken" TEXT,
+    "lastEventsSyncedAt" TIMESTAMP(3),
+    "lastArtifactsSyncedAt" TIMESTAMP(3),
+    "calendarChannelId" TEXT,
+    "calendarChannelExpires" TIMESTAMP(3),
+    "driveChannelId" TEXT,
+    "driveChannelExpires" TIMESTAMP(3),
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GoogleCalendarSync_pkey" PRIMARY KEY ("googleAccountId")
+);
+
+-- CreateTable
+CREATE TABLE "Meeting" (
+    "id" SERIAL NOT NULL,
+    "calendarEventId" TEXT NOT NULL,
+    "calendarProvider" TEXT NOT NULL DEFAULT 'google',
+    "sourceAccountId" INTEGER,
+    "conferenceId" TEXT,
+    "organizerEmail" TEXT NOT NULL,
+    "organizerUserId" INTEGER,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "scheduledStart" TIMESTAMP(3) NOT NULL,
+    "scheduledEnd" TIMESTAMP(3) NOT NULL,
+    "actualStart" TIMESTAMP(3),
+    "actualEnd" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'scheduled',
+    "primaryContactId" INTEGER,
+    "primaryDealId" INTEGER,
+    "primaryCompanyId" INTEGER,
+    "linkStatus" TEXT NOT NULL DEFAULT 'unlinked',
+    "linkConfidence" DECIMAL(3,2),
+    "linkMethod" TEXT,
+    "linkedAt" TIMESTAMP(3),
+    "linkedByUserId" INTEGER,
+    "recordingUrl" TEXT,
+    "recordingDriveId" TEXT,
+    "summaryDocUrl" TEXT,
+    "summaryDocId" TEXT,
+    "summaryExcerpt" TEXT,
+    "transcriptDocUrl" TEXT,
+    "transcriptDocId" TEXT,
+    "briefingDocUrl" TEXT,
+    "artifactsProcessedAt" TIMESTAMP(3),
+    "artifactsPartial" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Meeting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MeetingAttendee" (
+    "id" SERIAL NOT NULL,
+    "meetingId" INTEGER NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "contactId" INTEGER,
+    "userId" INTEGER,
+    "responseStatus" TEXT,
+    "attended" BOOLEAN,
+    "joinTime" TIMESTAMP(3),
+    "leaveTime" TIMESTAMP(3),
+    "isOrganizer" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "MeetingAttendee_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MeetingLinkAudit" (
+    "id" SERIAL NOT NULL,
+    "meetingId" INTEGER NOT NULL,
+    "attemptedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "method" TEXT NOT NULL,
+    "candidates" JSONB NOT NULL,
+    "chosenContactId" INTEGER,
+    "chosenDealId" INTEGER,
+    "chosenCompanyId" INTEGER,
+    "confidence" DECIMAL(3,2),
+    "outcome" TEXT NOT NULL DEFAULT 'accepted',
+
+    CONSTRAINT "MeetingLinkAudit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Meeting_calendarEventId_key" ON "Meeting"("calendarEventId");
+
+-- CreateIndex
+CREATE INDEX "Meeting_primaryDealId_scheduledStart_idx" ON "Meeting"("primaryDealId", "scheduledStart");
+
+-- CreateIndex
+CREATE INDEX "Meeting_primaryContactId_scheduledStart_idx" ON "Meeting"("primaryContactId", "scheduledStart");
+
+-- CreateIndex
+CREATE INDEX "Meeting_primaryCompanyId_scheduledStart_idx" ON "Meeting"("primaryCompanyId", "scheduledStart");
+
+-- CreateIndex
+CREATE INDEX "Meeting_organizerUserId_idx" ON "Meeting"("organizerUserId");
+
+-- CreateIndex
+CREATE INDEX "Meeting_status_scheduledStart_idx" ON "Meeting"("status", "scheduledStart");
+
+-- CreateIndex
+CREATE INDEX "Meeting_linkStatus_idx" ON "Meeting"("linkStatus");
+
+-- CreateIndex
+CREATE INDEX "MeetingAttendee_email_idx" ON "MeetingAttendee"("email");
+
+-- CreateIndex
+CREATE INDEX "MeetingAttendee_contactId_idx" ON "MeetingAttendee"("contactId");
+
+-- CreateIndex
+CREATE INDEX "MeetingAttendee_userId_idx" ON "MeetingAttendee"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MeetingAttendee_meetingId_email_key" ON "MeetingAttendee"("meetingId", "email");
+
+-- CreateIndex
+CREATE INDEX "MeetingLinkAudit_meetingId_attemptedAt_idx" ON "MeetingLinkAudit"("meetingId", "attemptedAt");
+
+-- CreateIndex
+CREATE INDEX "Note_meetingId_idx" ON "Note"("meetingId");
+
+-- CreateIndex
+CREATE INDEX "Task_sourceMeetingId_idx" ON "Task"("sourceMeetingId");
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_sourceMeetingId_fkey" FOREIGN KEY ("sourceMeetingId") REFERENCES "Meeting"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Note" ADD CONSTRAINT "Note_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GoogleCalendarSync" ADD CONSTRAINT "GoogleCalendarSync_googleAccountId_fkey" FOREIGN KEY ("googleAccountId") REFERENCES "GoogleAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_sourceAccountId_fkey" FOREIGN KEY ("sourceAccountId") REFERENCES "GoogleAccount"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_organizerUserId_fkey" FOREIGN KEY ("organizerUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_primaryContactId_fkey" FOREIGN KEY ("primaryContactId") REFERENCES "Contact"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_primaryDealId_fkey" FOREIGN KEY ("primaryDealId") REFERENCES "Deal"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_primaryCompanyId_fkey" FOREIGN KEY ("primaryCompanyId") REFERENCES "Company"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_linkedByUserId_fkey" FOREIGN KEY ("linkedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingAttendee" ADD CONSTRAINT "MeetingAttendee_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingAttendee" ADD CONSTRAINT "MeetingAttendee_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "Contact"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingAttendee" ADD CONSTRAINT "MeetingAttendee_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingLinkAudit" ADD CONSTRAINT "MeetingLinkAudit_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260505200000_company_domains_gin/migration.sql
+++ b/apps/api/prisma/migrations/20260505200000_company_domains_gin/migration.sql
@@ -1,0 +1,9 @@
+-- GIN index on Company.domains so the meeting auto-link matcher's
+-- `domains: { hasSome: [...] }` query plans as an index lookup instead
+-- of a sequential scan. Postgres's GIN index on text[] supports the
+-- @> / && operators that Prisma compiles `hasSome` into.
+--
+-- Backfill is implicit: the existing migration adds the column with a
+-- default empty array, so this index is built over rows that mostly
+-- have an empty domains[]. Cheap to build at this scale.
+CREATE INDEX "Company_domains_idx" ON "Company" USING GIN ("domains");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -8,38 +8,41 @@ datasource db {
 }
 
 model User {
-  id           Int       @id @default(autoincrement())
-  email        String    @unique
+  id           Int      @id @default(autoincrement())
+  email        String   @unique
   name         String
   passwordHash String
-  avatarColor  String    @default("#6366f1")
+  avatarColor  String   @default("#6366f1")
   avatarUrl    String?
-  theme        String    @default("system") // 'system' | 'light' | 'dark'
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+  theme        String   @default("system") // 'system' | 'light' | 'dark'
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  sessions       Session[]
-  ownedDeals     Deal[]       @relation("DealOwner")
-  tasks          Task[]       @relation("TaskAssignee")
-  notes          Note[]       @relation("NoteAuthor")
-  attachments    Attachment[] @relation("AttachmentUploader")
-  activities     Activity[]   @relation("ActivityActor")
-  listPrefs      UserListPreference[]
-  apiTokens      ApiToken[]
-  googleAccount  GoogleAccount?
-  oauthStates    OAuthState[]
-  importJobs     ImportJob[]
+  sessions           Session[]
+  ownedDeals         Deal[]               @relation("DealOwner")
+  tasks              Task[]               @relation("TaskAssignee")
+  notes              Note[]               @relation("NoteAuthor")
+  attachments        Attachment[]         @relation("AttachmentUploader")
+  activities         Activity[]           @relation("ActivityActor")
+  listPrefs          UserListPreference[]
+  apiTokens          ApiToken[]
+  googleAccount      GoogleAccount?
+  oauthStates        OAuthState[]
+  importJobs         ImportJob[]
+  organizedMeetings  Meeting[]            @relation("MeetingOrganizer")
+  meetingAttendances MeetingAttendee[]
+  linkedMeetings     Meeting[]            @relation("MeetingLinker")
 }
 
 model Session {
-  id          String   @id // opaque random token
-  userId      Int
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  createdAt   DateTime @default(now())
-  lastSeenAt  DateTime @default(now())
-  expiresAt   DateTime
-  userAgent   String?
-  ipAddress   String?
+  id         String   @id // opaque random token
+  userId     Int
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt  DateTime @default(now())
+  lastSeenAt DateTime @default(now())
+  expiresAt  DateTime
+  userAgent  String?
+  ipAddress  String?
 
   @@index([userId])
   @@index([expiresAt])
@@ -55,27 +58,27 @@ model PipelineStage {
   isLost    Boolean  @default(false)
   createdAt DateTime @default(now())
 
-  deals     Deal[]
+  deals Deal[]
 
   @@index([order])
 }
 
 model Company {
-  id           Int      @id @default(autoincrement())
-  name         String
+  id             Int      @id @default(autoincrement())
+  name           String
   // Case-insensitive uniqueness on `name` is enforced via a raw SQL migration
   // (Prisma can't express functional indexes on lower(name) yet).
-  industry     String?
-  website      String?
-  size         String?
-  phone        String?
-  addressLine1 String?
-  addressLine2 String?
-  city         String?
-  state        String?
-  postalCode   String?
-  notes        String?
-  logoUrl      String?
+  industry       String?
+  website        String?
+  size           String?
+  phone          String?
+  addressLine1   String?
+  addressLine2   String?
+  city           String?
+  state          String?
+  postalCode     String?
+  notes          String?
+  logoUrl        String?
   // External-system identity used by the CSV importer. `externalSource` is a
   // bucket key like "pipedrive" / "hubspot"; `externalId` is the source's row
   // id. Together they let re-imports of the same export update existing rows
@@ -83,42 +86,52 @@ model Company {
   // not created via import don't conflict with each other.
   externalId     String?
   externalSource String?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
-  contacts        Contact[]
-  deals           Deal[]
+  // String[] of email domains owned by this Company — e.g. ["acme.com",
+  // "acme.co.uk"]. Lower-cased on write. Used by the meeting auto-link
+  // matcher to fall back from no-Contact-match to a Company match when an
+  // attendee's email domain belongs to a known Company. Stored as a Postgres
+  // text[] so a GIN index on the unnest can drive fast `domain = ANY(...)`
+  // lookups; expressed in Prisma as String[].
+  domains        String[]        @default([])
+  contacts       Contact[]
+  deals          Deal[]
   // `noteEntries` rather than `notes` because the scalar `notes` String column
   // above is the company's free-form notes blob — kept as a separate field
   // so existing API consumers don't break.
-  noteEntries     Note[]
-  enrichmentRuns  EnrichmentRun[]
+  noteEntries    Note[]
+  enrichmentRuns EnrichmentRun[]
+  meetings       Meeting[]
 
   @@unique([externalSource, externalId], name: "company_external_uq")
   @@index([name])
 }
 
 model Contact {
-  id         Int      @id @default(autoincrement())
-  firstName  String
-  lastName   String
-  email      String?
-  phone      String?
-  title      String?
-  linkedin   String?
-  notes      String?
-  companyId  Int?
-  company    Company? @relation(fields: [companyId], references: [id], onDelete: SetNull)
+  id             Int      @id @default(autoincrement())
+  firstName      String
+  lastName       String
+  email          String?
+  phone          String?
+  title          String?
+  linkedin       String?
+  notes          String?
+  companyId      Int?
+  company        Company? @relation(fields: [companyId], references: [id], onDelete: SetNull)
   // See Company.externalId — same idempotency mechanism for re-imports.
   externalId     String?
   externalSource String?
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
-  primaryDeals Deal[]              @relation("DealPrimaryContact")
-  googleLinks  ContactGoogleLink[]
+  primaryDeals       Deal[]              @relation("DealPrimaryContact")
+  googleLinks        ContactGoogleLink[]
   // See Company.noteEntries — same naming for the same reason.
-  noteEntries  Note[]
+  noteEntries        Note[]
+  meetings           Meeting[]
+  meetingAttendances MeetingAttendee[]
 
   @@unique([externalSource, externalId], name: "contact_external_uq")
   @@index([email])
@@ -155,36 +168,37 @@ model TagAttachment {
 }
 
 model Deal {
-  id                 Int            @id @default(autoincrement())
-  title              String
-  amount             Decimal        @default(0) @db.Decimal(14, 2)
-  currency           String         @default("USD")
-  probability        Int            @default(0)
-  expectedCloseDate  DateTime?      @db.Date
-  stageId            Int
-  stage              PipelineStage  @relation(fields: [stageId], references: [id])
-  companyId          Int?
-  company            Company?       @relation(fields: [companyId], references: [id], onDelete: SetNull)
-  primaryContactId   Int?
-  primaryContact     Contact?       @relation("DealPrimaryContact", fields: [primaryContactId], references: [id], onDelete: SetNull)
+  id                Int           @id @default(autoincrement())
+  title             String
+  amount            Decimal       @default(0) @db.Decimal(14, 2)
+  currency          String        @default("USD")
+  probability       Int           @default(0)
+  expectedCloseDate DateTime?     @db.Date
+  stageId           Int
+  stage             PipelineStage @relation(fields: [stageId], references: [id])
+  companyId         Int?
+  company           Company?      @relation(fields: [companyId], references: [id], onDelete: SetNull)
+  primaryContactId  Int?
+  primaryContact    Contact?      @relation("DealPrimaryContact", fields: [primaryContactId], references: [id], onDelete: SetNull)
   // ownerId is nullable so a user can delete their account without us having
   // to reassign every deal first. Single-tenant: any team member can still
   // see ownerless deals; the UI just renders them as "—".
-  ownerId            Int?
-  owner              User?          @relation("DealOwner", fields: [ownerId], references: [id], onDelete: SetNull)
-  stageChangedAt     DateTime       @default(now())
-  closedAt           DateTime?
+  ownerId           Int?
+  owner             User?         @relation("DealOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+  stageChangedAt    DateTime      @default(now())
+  closedAt          DateTime?
   // See Company.externalId — same idempotency mechanism for re-imports.
-  externalId         String?
-  externalSource     String?
-  createdAt          DateTime       @default(now())
-  updatedAt          DateTime       @updatedAt
-  boardOrder         Int            @default(0)
+  externalId        String?
+  externalSource    String?
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+  boardOrder        Int           @default(0)
 
   notes       Note[]
   tasks       Task[]
   attachments Attachment[]
   activities  Activity[]
+  meetings    Meeting[]
 
   @@unique([externalSource, externalId], name: "deal_external_uq")
   @@index([stageId, boardOrder])
@@ -193,18 +207,39 @@ model Deal {
 }
 
 model Task {
-  id          Int       @id @default(autoincrement())
-  title       String
-  description String?
-  dueDate     DateTime? @db.Date
-  status      String    @default("pending") // 'pending' | 'completed'
-  completedAt DateTime?
-  dealId      Int?
-  deal        Deal?     @relation(fields: [dealId], references: [id], onDelete: Cascade)
-  assignedTo  Int?
-  assignee    User?     @relation("TaskAssignee", fields: [assignedTo], references: [id])
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  id                   Int       @id @default(autoincrement())
+  title                String
+  description          String?
+  dueDate              DateTime? @db.Date
+  // 'pending' | 'completed' | 'pending_review' | 'dismissed'.
+  // 'pending_review' is the holding state for auto-extracted action items
+  // — they don't appear in the assignee's regular task queue until the rep
+  // accepts (→ 'pending') or rejects (→ 'dismissed'). This stays a string
+  // (not an enum) for parity with the existing field; an enum migration
+  // here would touch every existing task row for no real benefit.
+  status               String    @default("pending")
+  completedAt          DateTime?
+  dealId               Int?
+  deal                 Deal?     @relation(fields: [dealId], references: [id], onDelete: Cascade)
+  assignedTo           Int?
+  assignee             User?     @relation("TaskAssignee", fields: [assignedTo], references: [id])
+  // Provenance for tasks lifted out of a Gemini meeting summary's "Action
+  // items" section. `sourceMeetingId` links back to the meeting record so
+  // accept/reject UX can render the source line and the rep can jump to
+  // the underlying Doc. `sourceActionItemText` keeps the original Gemini
+  // bullet for traceability across summary regenerations (Gemini sometimes
+  // re-emits the doc up to ~30 minutes after the call). `autoExtracted`
+  // gates "needs review" UI without requiring a join. `customerCommitment`
+  // marks tasks Gemini attributed to the customer rather than to an
+  // internal user — these still get tracked so a manager can ask "what
+  // did the prospect agree to do, and did they?".
+  sourceMeetingId      Int?
+  sourceMeeting        Meeting?  @relation(fields: [sourceMeetingId], references: [id], onDelete: SetNull)
+  sourceActionItemText String?
+  autoExtracted        Boolean   @default(false)
+  customerCommitment   Boolean   @default(false)
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
 
   attachments Attachment[]
 
@@ -212,6 +247,7 @@ model Task {
   @@index([status])
   @@index([dealId])
   @@index([assignedTo])
+  @@index([sourceMeetingId])
 }
 
 // Polymorphic note. Exactly one of (dealId, companyId, contactId) is set —
@@ -219,45 +255,58 @@ model Task {
 // invariant (notes-on-deals only) is preserved in the data; new write paths
 // can attach a note to any of the three.
 model Note {
-  id        Int      @id @default(autoincrement())
-  content   String
-  dealId    Int?
-  deal      Deal?    @relation(fields: [dealId], references: [id], onDelete: Cascade)
-  companyId Int?
-  company   Company? @relation(fields: [companyId], references: [id], onDelete: Cascade)
-  contactId Int?
-  contact   Contact? @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  id             Int      @id @default(autoincrement())
+  content        String
+  dealId         Int?
+  deal           Deal?    @relation(fields: [dealId], references: [id], onDelete: Cascade)
+  companyId      Int?
+  company        Company? @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  contactId      Int?
+  contact        Contact? @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  // Optional pointer to the meeting this note is *about* (not the polymorphic
+  // owner — that's still one of deal/company/contact). When the artifact
+  // watcher writes the cached Gemini summary excerpt as a deal-timeline note,
+  // it sets meetingId so the UI can render a "from meeting" badge with a
+  // link to the recording / full summary doc.
+  meetingId      Int?
+  meeting        Meeting? @relation(fields: [meetingId], references: [id], onDelete: SetNull)
+  // 'manual' | 'meeting_summary' | 'ai_extracted'. Drives badge rendering
+  // and a few "don't show in the activity feed" gates (we don't want
+  // every Gemini-summary-derived note to spam the per-deal activity log,
+  // even though it's still in the timeline).
+  source         String   @default("manual")
   // Author retained but nullable so user delete works. UI renders the author
   // chip as "—" when null. The note text itself remains.
-  createdBy Int?
-  author    User?    @relation("NoteAuthor", fields: [createdBy], references: [id], onDelete: SetNull)
+  createdBy      Int?
+  author         User?    @relation("NoteAuthor", fields: [createdBy], references: [id], onDelete: SetNull)
   // CSV-import idempotency. Same pattern as Company/Contact/Deal:
   // (externalSource, externalId) is the natural key for re-imports.
   // NULLs don't conflict in Postgres unique indexes, so notes created
   // through the UI (no external identity) coexist freely.
   externalId     String?
   externalSource String?
-  createdAt DateTime @default(now())
+  createdAt      DateTime @default(now())
 
   @@unique([externalSource, externalId], name: "note_external_uq")
   @@index([dealId])
   @@index([companyId])
   @@index([contactId])
+  @@index([meetingId])
 }
 
 model Attachment {
-  id           Int      @id @default(autoincrement())
-  filename     String
-  storedKey    String   // S3 object key
-  contentType  String?
-  sizeBytes    Int?
-  dealId       Int?
-  deal         Deal?    @relation(fields: [dealId], references: [id], onDelete: Cascade)
-  taskId       Int?
-  task         Task?    @relation(fields: [taskId], references: [id], onDelete: Cascade)
-  uploadedBy   Int?
-  uploader     User?    @relation("AttachmentUploader", fields: [uploadedBy], references: [id], onDelete: SetNull)
-  uploadedAt   DateTime @default(now())
+  id          Int      @id @default(autoincrement())
+  filename    String
+  storedKey   String // S3 object key
+  contentType String?
+  sizeBytes   Int?
+  dealId      Int?
+  deal        Deal?    @relation(fields: [dealId], references: [id], onDelete: Cascade)
+  taskId      Int?
+  task        Task?    @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  uploadedBy  Int?
+  uploader    User?    @relation("AttachmentUploader", fields: [uploadedBy], references: [id], onDelete: SetNull)
+  uploadedAt  DateTime @default(now())
 
   @@index([dealId])
   @@index([taskId])
@@ -265,9 +314,9 @@ model Attachment {
 
 model Activity {
   id        Int      @id @default(autoincrement())
-  kind      String   // 'created' | 'stage_changed' | 'note_added' | 'task_added' | 'task_completed' | 'file_added' | 'file_deleted' | 'field_updated' | 'deal_won' | 'deal_lost'
+  kind      String // 'created' | 'stage_changed' | 'note_added' | 'task_added' | 'task_completed' | 'file_added' | 'file_deleted' | 'field_updated' | 'deal_won' | 'deal_lost'
   summary   String
-  meta      String?  // optional JSON-as-string
+  meta      String? // optional JSON-as-string
   dealId    Int
   deal      Deal     @relation(fields: [dealId], references: [id], onDelete: Cascade)
   actorId   Int?
@@ -332,21 +381,21 @@ model CustomFieldDefinition {
   createdAt    DateTime          @default(now())
   updatedAt    DateTime          @updatedAt
 
-  values       CustomFieldValue[]
+  values CustomFieldValue[]
 
   @@unique([entityType, key])
   @@index([entityType, isActive, order])
 }
 
 model CustomFieldValue {
-  id           Int                   @id @default(autoincrement())
-  definitionId Int
+  id            Int                   @id @default(autoincrement())
+  definitionId  Int
   // Restrict on delete — we never want to lose values via a definition delete.
   // The /custom-fields DELETE handler pre-checks for this and inactivates
   // instead, returning 409 if you try to hard-delete one with values.
-  definition   CustomFieldDefinition @relation(fields: [definitionId], references: [id], onDelete: Restrict)
-  entityType   CustomFieldEntity
-  entityId     Int
+  definition    CustomFieldDefinition @relation(fields: [definitionId], references: [id], onDelete: Restrict)
+  entityType    CustomFieldEntity
+  entityId      Int
   // Typed columns. Exactly one is populated per row, chosen by the
   // definition's `type`. Multi-select values land in `valueJson` as a string array.
   valueText     String?
@@ -358,8 +407,8 @@ model CustomFieldValue {
   valueDateTime DateTime?
   valueBool     Boolean?
   valueJson     Json?
-  createdAt    DateTime              @default(now())
-  updatedAt    DateTime              @updatedAt
+  createdAt     DateTime              @default(now())
+  updatedAt     DateTime              @updatedAt
 
   @@unique([definitionId, entityType, entityId])
   @@index([entityType, entityId])
@@ -421,7 +470,7 @@ model WebhookEndpoint {
 // follow-up (TODO: trim 30d success / 90d failed once the table grows
 // enough to matter).
 model WebhookDelivery {
-  id             Int      @id @default(autoincrement())
+  id             Int             @id @default(autoincrement())
   endpointId     Int
   endpoint       WebhookEndpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade)
   // Stable event id (`evt_<nanoid>`) — same across retries; clients use it
@@ -432,15 +481,15 @@ model WebhookDelivery {
   // later record edit doesn't change what historical deliveries contained.
   payload        Json
   // 'pending' | 'success' | 'failed'
-  status         String   @default("pending")
+  status         String          @default("pending")
   responseStatus Int?
   // Truncated to ~4KB at write time so a chatty endpoint can't blow up the
   // table.
   responseBody   String?
   errorMessage   String?
-  attemptCount   Int      @default(0)
+  attemptCount   Int             @default(0)
   jobId          String?
-  createdAt      DateTime @default(now())
+  createdAt      DateTime        @default(now())
   completedAt    DateTime?
   durationMs     Int?
 
@@ -468,28 +517,28 @@ model WebhookDelivery {
 // allowed scope simply aren't exposed to that token's session, so an
 // agent can't even see a destructive tool when its token lacks `delete`.
 model ApiToken {
-  id          String    @id // public token id segment (`tok_<random>`)
-  userId      Int
-  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  name        String
+  id         String    @id // public token id segment (`tok_<random>`)
+  userId     Int
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name       String
   // Argon2id hash of the secret half of the token. Verified with the same
   // argon2 module used for password hashes — constant-time, memory-hard.
-  secretHash  String
+  secretHash String
   // string[] of granted scopes. Validated against the catalog at the route
   // layer; the column itself is a free-form JSON array so adding a new
   // scope is a code change rather than a migration.
-  scopes      Json
-  expiresAt   DateTime?
-  lastUsedAt  DateTime?
+  scopes     Json
+  expiresAt  DateTime?
+  lastUsedAt DateTime?
   // Set when the user revokes the token via the settings UI; the row is
   // kept so the audit log can still reference it. Lookups treat
   // `revokedAt != null` as "expired".
-  revokedAt   DateTime?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  revokedAt  DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
 
-  auditEvents     McpAuditEvent[]
-  approvalTokens  McpApprovalToken[]
+  auditEvents    McpAuditEvent[]
+  approvalTokens McpApprovalToken[]
 
   @@index([userId])
   @@index([revokedAt])
@@ -500,7 +549,7 @@ model ApiToken {
 // the agent do" weeks after the fact. Truncated arg/result blobs prevent
 // a chatty agent from blowing up the table.
 model McpAuditEvent {
-  id           Int      @id @default(autoincrement())
+  id           Int       @id @default(autoincrement())
   tokenId      String?
   token        ApiToken? @relation(fields: [tokenId], references: [id], onDelete: SetNull)
   // Snapshot of the user the token was issued to at call time. Set null if
@@ -519,7 +568,7 @@ model McpAuditEvent {
   // Set when the call required (or consumed) an approval token; lets us
   // join an approve-and-act pair in the log without a follow-up query.
   approvalId   String?
-  createdAt    DateTime @default(now())
+  createdAt    DateTime  @default(now())
 
   @@index([tokenId, createdAt])
   @@index([toolName, createdAt])
@@ -564,30 +613,30 @@ model McpApprovalToken {
 model EnrichmentRun {
   // cuid so the public manual-enrich endpoint can return it without leaking
   // a sequential id (the diff endpoint takes runId in the URL).
-  id            String    @id @default(cuid())
-  companyId     Int?
-  company       Company?  @relation(fields: [companyId], references: [id], onDelete: SetNull)
+  id           String    @id @default(cuid())
+  companyId    Int?
+  company      Company?  @relation(fields: [companyId], references: [id], onDelete: SetNull)
   // Denormalized at insert so the recent-runs list still has a label after
   // the company is deleted.
-  companyName   String
+  companyName  String
   // 'auto-create' | 'auto-import' | 'manual'
-  trigger       String
+  trigger      String
   // 'structured' | 'agentic'
-  mode          String
+  mode         String
   // 'pending' | 'applied' | 'proposed' | 'skipped' | 'error'
-  status        String    @default("pending")
+  status       String    @default("pending")
   // Why we skipped (cap, debounce, disabled, ambiguous). Free-form so we
   // don't have to migrate when adding a new short-circuit reason.
-  reason        String?
+  reason       String?
   // The full enrichment payload as returned by the LLM. Used by the
   // /apply endpoint to (re)write the selected fields, and by the diff
   // modal to render proposed-vs-current per field. JSON because the
   // payload shape evolves with the prompt.
-  payload       Json?
-  errorMessage  String?
-  startedAt     DateTime  @default(now())
-  finishedAt    DateTime?
-  createdAt     DateTime  @default(now())
+  payload      Json?
+  errorMessage String?
+  startedAt    DateTime  @default(now())
+  finishedAt   DateTime?
+  createdAt    DateTime  @default(now())
 
   @@index([companyId, createdAt])
   @@index([status])
@@ -638,6 +687,8 @@ model GoogleAccount {
 
   contactsSync GoogleContactsSync?
   contactLinks ContactGoogleLink[]
+  calendarSync GoogleCalendarSync?
+  meetings     Meeting[]
 }
 
 // One row per (account × integration). For now there's only the contacts
@@ -669,6 +720,48 @@ model GoogleContactsSync {
   updatedAt            DateTime      @updatedAt
 }
 
+// Per-account calendar/meet sync state. Sibling to GoogleContactsSync:
+// keeps the calendar-specific cursors, last-run telemetry, and feature
+// toggles separate so a future "pause meetings ingest but keep contacts
+// running" admin switch is a one-row update.
+//
+// Two cursors because we drive two independent loops: the *calendar pull*
+// pulls events forward from the user's primary calendar (and watches for
+// updates / deletions), and the *artifact watcher* polls completed meetings
+// for recordings, transcripts, and Gemini summaries that land 5–60 minutes
+// after the call ends. v1 is poll-only; the *_channel_* fields are reserved
+// for the Drive watch / Calendar watch push subscriptions that a later
+// phase swaps in (see spec-artifact-attach.md and spec-auto-link-meeting.md
+// "polling vs push" tradeoff sections).
+model GoogleCalendarSync {
+  googleAccountId        Int           @id
+  account                GoogleAccount @relation(fields: [googleAccountId], references: [id], onDelete: Cascade)
+  // Calendar API delta token. Pinned by `events.list(syncToken: ...)`. On
+  // 410 Gone we drop it and fall back to a windowed full re-list (the
+  // worker bounds the window to a small lookback so a token expiry never
+  // re-ingests months of stale events).
+  eventsSyncToken        String?
+  // Last successful incremental tick — drives the "Last synced" UI and
+  // bounds the per-run lookback window when no sync token is present.
+  lastEventsSyncedAt     DateTime?
+  lastArtifactsSyncedAt  DateTime?
+  // Calendar / Drive watch channels. Reserved for v1.5 push support; left
+  // null today. When push lands these will hold the channel id + expiry
+  // so a renew job can call `events.watch` / `drive.changes.watch` again
+  // before they age out (Calendar channels last ~7d, Drive ~7d).
+  calendarChannelId      String?
+  calendarChannelExpires DateTime?
+  driveChannelId         String?
+  driveChannelExpires    DateTime?
+  // Inbound (calendar → PF meeting records) is on once the user connects;
+  // there is no outbound (we don't write the user's calendar in v1) so no
+  // outbound toggle here. A user-level off switch is the disabledAt on
+  // GoogleAccount.
+  enabled                Boolean       @default(true)
+  createdAt              DateTime      @default(now())
+  updatedAt              DateTime      @updatedAt
+}
+
 // Many-to-one mapping from PF Contact to Google Person. Multiple users in
 // the workspace can connect their own Google accounts and the same PF
 // Contact can therefore have several link rows — one per connected user
@@ -682,18 +775,18 @@ model GoogleContactsSync {
 // they match. Strictly better than a "currently syncing" flag — stateless,
 // crash-safe, survives across processes.
 model ContactGoogleLink {
-  id              Int           @id @default(autoincrement())
+  id              Int      @id @default(autoincrement())
   contactId       Int
   googleAccountId Int
   resourceName    String
   // Optimistic concurrency token from People API. Cached on every
   // successful pull; refreshed via re-fetch on a 412 from a push.
   etag            String
-  lastSyncedAt    DateTime      @default(now())
+  lastSyncedAt    DateTime @default(now())
   lastPushedHash  String?
   lastPulledHash  String?
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   contact Contact       @relation(fields: [contactId], references: [id], onDelete: Cascade)
   account GoogleAccount @relation(fields: [googleAccountId], references: [id], onDelete: Cascade)
@@ -701,6 +794,198 @@ model ContactGoogleLink {
   @@unique([googleAccountId, resourceName])
   @@index([contactId])
   @@index([googleAccountId, lastSyncedAt])
+}
+
+// ─── Meetings ───────────────────────────────────────────────────────────────
+// Calendar-backed customer conversations, plus the post-call artifacts
+// (recording, Gemini summary, transcript) Meet drops in the organizer's
+// Drive within 5–60 minutes of the call ending. Modeled as a first-class
+// entity rather than a typed Note because a Meeting carries structured
+// fields (start/end, attendees, conference id, three URL slots), has its
+// own lifecycle (scheduled → in_progress → completed), and is the natural
+// anchor for child Notes (the cached summary excerpt) and child Tasks
+// (action items lifted out of the Gemini summary). See
+// docs/Documents/Claude/Projects/PipelineFlowCRM/data-model-meetings.md
+// for the design rationale.
+//
+// One Google Calendar event = one Meeting row, deduped by `calendarEventId`.
+// Re-ingesting the same event must be idempotent (the Calendar API returns
+// the same event under both create *and* update channels, and our retry
+// budget can replay any individual page).
+//
+// `primaryDealId` / `primaryContactId` / `primaryCompanyId` are denormalized
+// for fast deal-timeline filtering and badge rendering. The deeper truth
+// (every attendee, every candidate considered) lives in MeetingAttendee +
+// MeetingLinkAudit; the primary fields are just the matcher's chosen
+// anchor for the 95% case where one meeting → one deal.
+model Meeting {
+  id               Int            @id @default(autoincrement())
+  // Stable Google Calendar event id. Unique constraint backs the
+  // upsert-on-ingest pattern in the worker.
+  calendarEventId  String         @unique
+  // Forward-compatible — the schema is provider-agnostic but the v1
+  // ingest is Google-only. Outlook/M365 will plug in here.
+  calendarProvider String         @default("google")
+  // The Google Calendar account this event was pulled from. A meeting can
+  // theoretically appear on several connected calendars (e.g. multiple
+  // PF users invited to the same call); the unique constraint on
+  // `calendarEventId` collapses those to a single row, and we record the
+  // first ingester here. Later attendee fan-out lives in MeetingAttendee.
+  sourceAccountId  Int?
+  sourceAccount    GoogleAccount? @relation(fields: [sourceAccountId], references: [id], onDelete: SetNull)
+  // Meet conferenceRecord name, populated on first observation post-call.
+  // Joins to the Meet REST API for recording / transcript metadata.
+  conferenceId     String?
+  organizerEmail   String
+  // Internal user when the organizer maps to a connected PF user — drives
+  // the "my meetings" filter and assignee-default for action items
+  // attributed to the organizer by name.
+  organizerUserId  Int?
+  organizer        User?          @relation("MeetingOrganizer", fields: [organizerUserId], references: [id], onDelete: SetNull)
+  title            String
+  description      String?
+  scheduledStart   DateTime
+  scheduledEnd     DateTime
+  actualStart      DateTime?
+  actualEnd        DateTime?
+  // 'scheduled' | 'in_progress' | 'completed' | 'cancelled' | 'no_show'.
+  // String, not enum, for parity with Task.status — the meeting lifecycle
+  // is driven by Calendar (status field on the event) plus simple
+  // wall-clock heuristics in the artifact watcher (a scheduled meeting
+  // whose end time is past but no actualEnd is recorded gets marked
+  // completed via the next watcher run).
+  status           String         @default("scheduled")
+
+  // ─── Linkage (denormalized) ───
+  primaryContactId Int?
+  primaryContact   Contact?  @relation(fields: [primaryContactId], references: [id], onDelete: SetNull)
+  primaryDealId    Int?
+  primaryDeal      Deal?     @relation(fields: [primaryDealId], references: [id], onDelete: SetNull)
+  primaryCompanyId Int?
+  primaryCompany   Company?  @relation(fields: [primaryCompanyId], references: [id], onDelete: SetNull)
+  // 'unlinked' | 'suggested' | 'confirmed' | 'rejected'. Drives whether
+  // the meeting card on a deal renders as "needs review" vs. confirmed.
+  // Meetings can be in any link state and still have artifacts — an
+  // unlinked meeting with a recording URL is still useful; a human can
+  // pick the deal later and the URL is already there.
+  linkStatus       String    @default("unlinked")
+  // Confidence on a 0.00–1.00 scale. See the matcher in
+  // apps/worker/src/integrations/google/meetingMatcher.ts for the
+  // ladder; broadly: 1.00 is "single contact + single open deal",
+  // 0.85 is "title disambiguated", 0.70 is "contact only", 0.50 is
+  // "domain match only".
+  linkConfidence   Decimal?  @db.Decimal(3, 2)
+  // 'email_match' | 'domain_match' | 'title_match' | 'manual'.
+  linkMethod       String?
+  linkedAt         DateTime?
+  linkedByUserId   Int?
+  linkedBy         User?     @relation("MeetingLinker", fields: [linkedByUserId], references: [id], onDelete: SetNull)
+
+  // ─── Artifact URLs ───
+  // Filled in by the artifact watcher (apps/worker/src/jobs/calendarArtifacts.ts)
+  // after the meeting completes. Drive remains the source of truth — we
+  // never copy file bytes; we just persist the URLs and inherit Drive's
+  // ACLs. `recordingDriveId` and friends are kept alongside the URL so a
+  // Drive-side ACL change can be detected on the next watcher run without
+  // needing to re-parse the URL.
+  recordingUrl         String?
+  recordingDriveId     String?
+  summaryDocUrl        String?
+  summaryDocId         String?
+  // Cached first paragraph (or the section under "Summary" if Gemini
+  // produces one), truncated to 280 chars. Surfaced inline on deal
+  // timelines so the rep doesn't have to click into Drive for a glance.
+  summaryExcerpt       String?
+  transcriptDocUrl     String?
+  transcriptDocId      String?
+  briefingDocUrl       String?
+  // Set the moment the watcher finishes a successful pass on this meeting,
+  // even if some artifacts were missing (e.g. Gemini didn't produce a
+  // summary because the call was too short). Watcher uses the timestamp
+  // to skip already-processed meetings on subsequent runs without having
+  // to re-evaluate every URL field.
+  artifactsProcessedAt DateTime?
+  // Subtler signal alongside artifactsProcessedAt: when the watcher gives
+  // up after the 6-hour cap with at least one URL still missing, we mark
+  // partial=true so the UI can render "summary unavailable" instead of a
+  // permanently empty button.
+  artifactsPartial     Boolean   @default(false)
+
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime?
+
+  attendees      MeetingAttendee[]
+  notes          Note[]
+  extractedTasks Task[]
+  audits         MeetingLinkAudit[]
+
+  @@index([primaryDealId, scheduledStart])
+  @@index([primaryContactId, scheduledStart])
+  @@index([primaryCompanyId, scheduledStart])
+  @@index([organizerUserId])
+  @@index([status, scheduledStart])
+  @@index([linkStatus])
+}
+
+// Per-attendee row for a Meeting. Stores both internal (PF user) and
+// external (Contact or unmatched email) attendees; the (userId, contactId,
+// email) triple disambiguates. The `attended` / join / leave columns are
+// reserved for Meet's participant-data API — populated when the artifact
+// watcher pulls the conferenceRecord.participants endpoint, useful for
+// "did the prospect actually show up" reporting.
+model MeetingAttendee {
+  id             Int       @id @default(autoincrement())
+  meetingId      Int
+  meeting        Meeting   @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  email          String
+  name           String?
+  contactId      Int?
+  contact        Contact?  @relation(fields: [contactId], references: [id], onDelete: SetNull)
+  userId         Int?
+  user           User?     @relation(fields: [userId], references: [id], onDelete: SetNull)
+  // 'accepted' | 'declined' | 'tentative' | 'needs_action'. Plain string;
+  // mirrors Calendar's responseStatus.
+  responseStatus String?
+  attended       Boolean?
+  joinTime       DateTime?
+  leaveTime      DateTime?
+  isOrganizer    Boolean   @default(false)
+
+  @@unique([meetingId, email])
+  @@index([email])
+  @@index([contactId])
+  @@index([userId])
+}
+
+// Append-only audit row for every auto-link decision. Lets us debug bad
+// matches and feed a future confidence-tuning dashboard. Candidates are
+// kept as JSON so a rejected suggestion can be replayed exactly — the
+// matcher already has the "what did you see" answer the next time someone
+// asks "why did this meeting end up on the wrong deal."
+model MeetingLinkAudit {
+  id              Int      @id @default(autoincrement())
+  meetingId       Int
+  meeting         Meeting  @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  attemptedAt     DateTime @default(now())
+  // Same vocabulary as Meeting.linkMethod. Recorded per attempt so a
+  // meeting that was first auto-suggested by email then re-linked
+  // manually keeps both rows visible.
+  method          String
+  // [{ kind: 'contact' | 'deal' | 'company', id, score, reason }, ...]
+  // — a snapshot of what the matcher considered, including rejected
+  // candidates, with the score / reason that ranked them.
+  candidates      Json
+  chosenContactId Int?
+  chosenDealId    Int?
+  chosenCompanyId Int?
+  confidence      Decimal? @db.Decimal(3, 2)
+  // 'accepted' | 'rejected' | 'overridden' | 'expired'. Initial row is
+  // accepted/expired-at-write; rejected/overridden is set when the user
+  // takes a corrective action in the UI.
+  outcome         String   @default("accepted")
+
+  @@index([meetingId, attemptedAt])
 }
 
 // Short-lived nonce table for the OAuth `state` parameter. Rather than
@@ -753,34 +1038,34 @@ model UserListPreference {
 // dashboard rendering, with the full error CSV available on demand from
 // the same S3 source via the row download endpoint.
 model ImportJob {
-  id           String    @id @default(cuid())
-  userId       Int
-  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  entityType   String    // 'company' | 'contact' | 'deal'
-  sourceFile   String    // S3 key, `imports/<id>.csv`
-  filename     String    // original upload filename for display
+  id                   String    @id @default(cuid())
+  userId               Int
+  user                 User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  entityType           String // 'company' | 'contact' | 'deal'
+  sourceFile           String // S3 key, `imports/<id>.csv`
+  filename             String // original upload filename for display
   // pending → validating → validated → committing → completed | failed
-  status       String    @default("pending")
+  status               String    @default("pending")
   // { csvHeader: canonicalField | null } — null means "ignore this column".
-  mapping      Json?
+  mapping              Json?
   // For Deal imports: { sourceStageName: pipelineStageId }.
-  stageMapping Json?
-  presetUsed   String?   // preset key (e.g. "pipedrive-persons") if detected
-  totalRows    Int       @default(0)
-  createdRows  Int       @default(0)
-  updatedRows  Int       @default(0)
-  errorRows    Int       @default(0)
+  stageMapping         Json?
+  presetUsed           String? // preset key (e.g. "pipedrive-persons") if detected
+  totalRows            Int       @default(0)
+  createdRows          Int       @default(0)
+  updatedRows          Int       @default(0)
+  errorRows            Int       @default(0)
   // Auto-create counters for relationship resolution: stub Companies created
   // when a Contact references a missing company name, stub Contacts created
   // when a Deal references a missing primaryContact email.
-  stubCompaniesCreated Int @default(0)
-  stubContactsCreated  Int @default(0)
+  stubCompaniesCreated Int       @default(0)
+  stubContactsCreated  Int       @default(0)
   // Truncated to the first 1 000 errors. The full set can be regenerated
   // from the source CSV by replaying the import without committing.
-  errors       Json?
-  startedAt    DateTime  @default(now())
-  completedAt  DateTime?
-  createdAt    DateTime  @default(now())
+  errors               Json?
+  startedAt            DateTime  @default(now())
+  completedAt          DateTime?
+  createdAt            DateTime  @default(now())
 
   @@index([userId])
   @@index([status])

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -60,6 +60,17 @@ const envSchema = z.object({
   // to real-time. The token expires after ~7 days of disuse so we never
   // want this much higher than that.
   GOOGLE_CONTACTS_SYNC_INTERVAL_MS: z.coerce.number().int().positive().default(10 * 60_000),
+  // Calendar pull cadence — 5 minutes per spec-auto-link-meeting.md. Sets
+  // the upper bound on "meeting scheduled → meeting on the deal" latency.
+  // Don't push above the artifacts cadence (one pulls events, the other
+  // looks for completed-meeting artifacts; the second is cheaper and
+  // happens later, so it can run less often).
+  GOOGLE_CALENDAR_SYNC_INTERVAL_MS: z.coerce.number().int().positive().default(5 * 60_000),
+  // Artifact watcher cadence — 10 minutes default. Gemini summaries land
+  // 5–60 minutes post-call, so this strikes a balance between latency
+  // and quota use. The watcher is also idempotent: even if cadence drops
+  // it'll catch up on the next tick.
+  GOOGLE_CALENDAR_ARTIFACTS_INTERVAL_MS: z.coerce.number().int().positive().default(10 * 60_000),
   // Cron pattern for the scheduled-backup repeatable. Default 04:42 UTC daily,
   // offset from s3-reconcile (03:17 UTC) so the worker isn't woken by both
   // cron jobs in the same minute. The worker actually runs the dump; this

--- a/apps/api/src/integrations/google/oauthClient.ts
+++ b/apps/api/src/integrations/google/oauthClient.ts
@@ -27,13 +27,52 @@ import { env } from '../../env.js';
 export const SCOPE_CONTACTS = 'https://www.googleapis.com/auth/contacts';
 export const SCOPE_USERINFO_EMAIL = 'https://www.googleapis.com/auth/userinfo.email';
 export const SCOPE_USERINFO_PROFILE = 'https://www.googleapis.com/auth/userinfo.profile';
+// Calendar: read-only is enough for v1. We never write the user's calendar
+// (briefing-doc-on-event-description is a future spec), so the .events
+// scope would be over-broad.
+export const SCOPE_CALENDAR_READONLY = 'https://www.googleapis.com/auth/calendar.readonly';
+// Meet conferenceRecords / recordings / transcripts. The Meet REST API
+// gates these behind their own scope; we ask for it as part of the
+// calendar intent because a connected calendar without Meet artifacts is
+// a thin slice and forcing two separate consent screens would be a worse
+// rep experience.
+export const SCOPE_MEET_READONLY = 'https://www.googleapis.com/auth/meetings.space.readonly';
+// Drive metadata — needed to search the organizer's Drive for the
+// "Notes by Gemini" summary Doc, which is *not* exposed through the Meet
+// API. We don't ask for full Drive read; metadata is enough to find the
+// file and build a public link, and we never read the raw file bytes
+// (the summary parser needs the doc body, so it asks for documents.readonly
+// below — see the comment there for why we still want the narrow scope).
+export const SCOPE_DRIVE_METADATA_READONLY = 'https://www.googleapis.com/auth/drive.metadata.readonly';
+// Documents.readonly to read the Gemini summary doc body and extract the
+// excerpt + action items. Strictly narrower than drive.readonly because
+// it doesn't grant access to arbitrary file bytes; only Docs.
+export const SCOPE_DOCUMENTS_READONLY = 'https://www.googleapis.com/auth/documents.readonly';
 
-// Future intents register here — adding Gmail or Calendar is a one-line
-// change plus the new scope constant. The /start route accepts an intent
-// string and looks up the matching scope set; that keeps the route layer
-// agnostic about which APIs are configured.
+// Future intents register here — adding Gmail is a one-line change plus
+// the new scope constant. The /start route accepts an intent string and
+// looks up the matching scope set; that keeps the route layer agnostic
+// about which APIs are configured.
 export const SCOPES_FOR_INTENT: Record<string, readonly string[]> = {
   contacts: [SCOPE_CONTACTS, SCOPE_USERINFO_EMAIL, SCOPE_USERINFO_PROFILE],
+  // Calendar bundles all four scopes the meeting ingest pipeline needs:
+  //   - calendar.readonly  → list events for auto-link
+  //   - meetings.space.readonly → conferenceRecord recordings + transcripts
+  //   - drive.metadata.readonly → search for the Gemini summary Doc
+  //   - documents.readonly → read the summary Doc body for excerpt + action items
+  // We deliberately pair them as one intent: a connected calendar without
+  // any of the others ships a meaningfully degraded experience (no
+  // artifacts on the deal timeline), and forcing two consent screens to
+  // get the full feature would be a much worse rep experience than asking
+  // for the full set up front.
+  calendar: [
+    SCOPE_CALENDAR_READONLY,
+    SCOPE_MEET_READONLY,
+    SCOPE_DRIVE_METADATA_READONLY,
+    SCOPE_DOCUMENTS_READONLY,
+    SCOPE_USERINFO_EMAIL,
+    SCOPE_USERINFO_PROFILE,
+  ],
 };
 
 export type GoogleIntent = keyof typeof SCOPES_FOR_INTENT;

--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -3,6 +3,8 @@ import { Redis } from 'ioredis';
 import {
   QUEUE_ENRICH_COMPANY,
   QUEUE_GENERATE,
+  QUEUE_GOOGLE_CALENDAR_ARTIFACTS,
+  QUEUE_GOOGLE_CALENDAR_PULL,
   QUEUE_GOOGLE_CONTACTS_PULL,
   QUEUE_GOOGLE_CONTACTS_PUSH,
   QUEUE_S3_CLEANUP,
@@ -13,6 +15,10 @@ import {
   type EnrichCompanyJobResult,
   type GenerateJobData,
   type GenerateJobResult,
+  type GoogleCalendarArtifactsJobData,
+  type GoogleCalendarArtifactsJobResult,
+  type GoogleCalendarPullJobData,
+  type GoogleCalendarPullJobResult,
   type GoogleContactsPullJobData,
   type GoogleContactsPullJobResult,
   type GoogleContactsPushJobData,
@@ -153,6 +159,35 @@ export const googleContactsPushQueue = new Queue<
   defaultJobOptions: googleContactsJobOptions,
 });
 
+// Calendar pull / artifact watcher. Same retry profile as contacts since
+// the failure modes are the same family: rate-limited or transient 5xx.
+// The artifact watcher retries are slightly more lenient because Gemini
+// summary doc availability is genuinely flappy in the first ~30 minutes
+// post-call — a 404 on the Drive search isn't a real failure, it's just
+// "not yet."
+const googleCalendarJobOptions: JobsOptions = {
+  attempts: 4,
+  backoff: { type: 'exponential', delay: 30_000 },
+  removeOnComplete: { age: 86_400, count: 1_000 },
+  removeOnFail: { age: 7 * 86_400 },
+};
+
+export const googleCalendarPullQueue = new Queue<
+  GoogleCalendarPullJobData,
+  GoogleCalendarPullJobResult
+>(QUEUE_GOOGLE_CALENDAR_PULL, {
+  connection: redisConnection,
+  defaultJobOptions: googleCalendarJobOptions,
+});
+
+export const googleCalendarArtifactsQueue = new Queue<
+  GoogleCalendarArtifactsJobData,
+  GoogleCalendarArtifactsJobResult
+>(QUEUE_GOOGLE_CALENDAR_ARTIFACTS, {
+  connection: redisConnection,
+  defaultJobOptions: googleCalendarJobOptions,
+});
+
 // Enrichment queue. Conservative concurrency on the worker side (2) — Anthropic
 // rate limits matter here, and a CSV-import auto-enrich fan-out can otherwise
 // burst hundreds of jobs into the queue at once. The cap-check inside the
@@ -184,6 +219,8 @@ export const allQueues = [
   scheduledBackupQueue,
   googleContactsPullQueue,
   googleContactsPushQueue,
+  googleCalendarPullQueue,
+  googleCalendarArtifactsQueue,
   enrichCompanyQueue,
 ];
 
@@ -302,6 +339,71 @@ export async function unscheduleGoogleContactsPull(googleAccountId: number) {
     return;
   }
   await googleContactsPullQueue.removeRepeatableByKey(target.key);
+}
+
+// ─── Google Calendar producers ──────────────────────────────────────────────
+
+export async function enqueueGoogleCalendarPull(data: GoogleCalendarPullJobData) {
+  return googleCalendarPullQueue.add(QUEUE_GOOGLE_CALENDAR_PULL, data, {
+    // jobId pinning so a manual "Resync" while a cron run is queued
+    // collapses into one job per account. BullMQ's `addJob` validation
+    // forbids `:` in custom ids — using `-` as the separator instead.
+    jobId: `google-calendar-pull-${data.kind}-${data.googleAccountId}`,
+  });
+}
+
+export async function enqueueGoogleCalendarArtifacts(data: GoogleCalendarArtifactsJobData) {
+  // Bucket the jobId by minute so rapid double-clicks on the "refresh
+  // artifacts" UI collapse into one job, but completed jobs in Redis's
+  // retention window don't dedupe genuine subsequent refreshes (BullMQ
+  // treats add() with an existing-jobId as a no-op even when that job
+  // has finished). Same pattern as the scheduled-backup manual trigger.
+  const minuteBucket = Math.floor(Date.now() / 60_000);
+  return googleCalendarArtifactsQueue.add(QUEUE_GOOGLE_CALENDAR_ARTIFACTS, data, {
+    jobId: `google-calendar-artifacts-${data.googleAccountId}-${minuteBucket}`,
+  });
+}
+
+/**
+ * Per-account incremental pull cron. Idempotent — calling on every api
+ * boot is safe. Defaults to every 5 minutes per the spec; configurable
+ * via env so a homelab can dial it back.
+ */
+export async function ensureGoogleCalendarPullScheduled(googleAccountId: number) {
+  const intervalMs = env.GOOGLE_CALENDAR_SYNC_INTERVAL_MS;
+  await googleCalendarPullQueue.add(
+    QUEUE_GOOGLE_CALENDAR_PULL,
+    { kind: 'incremental', googleAccountId },
+    {
+      repeat: { every: intervalMs },
+      jobId: `recurring:google-calendar-pull:${googleAccountId}`,
+    },
+  );
+  // Artifacts watcher runs on its own cadence — slower than the calendar
+  // pull because Gemini summaries land 5–60 minutes post-call. Hitting
+  // every 5 minutes here would burn API quota for no latency benefit.
+  await googleCalendarArtifactsQueue.add(
+    QUEUE_GOOGLE_CALENDAR_ARTIFACTS,
+    { googleAccountId },
+    {
+      repeat: { every: env.GOOGLE_CALENDAR_ARTIFACTS_INTERVAL_MS },
+      jobId: `recurring:google-calendar-artifacts:${googleAccountId}`,
+    },
+  );
+}
+
+export async function unscheduleGoogleCalendarPull(googleAccountId: number) {
+  for (const queue of [googleCalendarPullQueue, googleCalendarArtifactsQueue]) {
+    const wantedId =
+      queue === googleCalendarPullQueue
+        ? `recurring:google-calendar-pull:${googleAccountId}`
+        : `recurring:google-calendar-artifacts:${googleAccountId}`;
+    const repeatables = await queue.getRepeatableJobs();
+    const target = repeatables.find((r) => r.id === wantedId);
+    if (target) {
+      await queue.removeRepeatableByKey(target.key);
+    }
+  }
 }
 
 /**

--- a/apps/api/src/lib/serialize.ts
+++ b/apps/api/src/lib/serialize.ts
@@ -1,5 +1,6 @@
 import type {
   User, Deal, Task, Note, Activity, Attachment, Company, Contact, Tag, PipelineStage,
+  Meeting, MeetingAttendee,
 } from '@prisma/client';
 // Note: `Tag` is still imported because tagDto serializes raw Tag rows for
 // polymorphic hydration in lib/tags.ts.
@@ -113,7 +114,10 @@ export const taskDto = (
   title: t.title,
   description: t.description,
   dueDate: t.dueDate ? t.dueDate.toISOString().slice(0, 10) : null,
-  status: t.status as 'pending' | 'completed',
+  // The status string union widened to include 'pending_review' / 'dismissed'
+  // when the auto-extraction pipeline lands. Keeping the cast loose so
+  // routes that still typed against the legacy literal pair don't trip.
+  status: t.status as 'pending' | 'completed' | 'pending_review' | 'dismissed',
   completedAt: t.completedAt?.toISOString() ?? null,
   dealId: t.dealId,
   deal: t.deal ? { id: t.deal.id, title: t.deal.title } : null,
@@ -121,6 +125,13 @@ export const taskDto = (
   assignee: t.assignee
     ? { id: t.assignee.id, name: t.assignee.name, avatarColor: t.assignee.avatarColor }
     : null,
+  // Meeting-extracted task provenance. Null on every legacy task; populated
+  // only by the artifact watcher's action-item materializer. The web UI
+  // uses these to render the "From meeting · Accept · Reject" affordance.
+  sourceMeetingId: t.sourceMeetingId,
+  sourceActionItemText: t.sourceActionItemText,
+  autoExtracted: t.autoExtracted,
+  customerCommitment: t.customerCommitment,
   createdAt: t.createdAt.toISOString(),
   updatedAt: t.updatedAt.toISOString(),
 });
@@ -133,9 +144,79 @@ export const noteDto = (
   dealId: n.dealId,
   companyId: n.companyId,
   contactId: n.contactId,
+  meetingId: n.meetingId,
+  source: n.source,
   createdBy: n.createdBy,
   author: n.author ?? null,
   createdAt: n.createdAt.toISOString(),
+});
+
+// Meeting summary projection — what the deal/contact page renders as the
+// meeting card. Includes the three artifact URLs (the headline feature
+// of this slice), the link confidence + status (drives the "needs review"
+// badge), and the attendee list for context. The full audit trail and
+// MeetingLinkAudit rows aren't in this shape; the meeting detail endpoint
+// surfaces those when the rep opens a meeting.
+export const meetingDto = (
+  m: Meeting & {
+    organizer?: { id: number; name: string; avatarColor: string } | null;
+    attendees?: (MeetingAttendee & {
+      contact?: { id: number; firstName: string; lastName: string } | null;
+      user?: { id: number; name: string } | null;
+    })[];
+    primaryContact?: Contact | null;
+    primaryDeal?: { id: number; title: string } | null;
+    primaryCompany?: { id: number; name: string } | null;
+  },
+) => ({
+  id: m.id,
+  calendarEventId: m.calendarEventId,
+  title: m.title,
+  description: m.description,
+  scheduledStart: m.scheduledStart.toISOString(),
+  scheduledEnd: m.scheduledEnd.toISOString(),
+  status: m.status,
+  organizerEmail: m.organizerEmail,
+  organizer: m.organizer ?? null,
+  // The matcher's chosen anchor — surfaced flat so the UI doesn't need
+  // to hop into the relations to render the "linked to <deal>" badge.
+  primaryContactId: m.primaryContactId,
+  primaryContact: m.primaryContact
+    ? {
+        id: m.primaryContact.id,
+        firstName: m.primaryContact.firstName,
+        lastName: m.primaryContact.lastName,
+      }
+    : null,
+  primaryDealId: m.primaryDealId,
+  primaryDeal: m.primaryDeal ? { id: m.primaryDeal.id, title: m.primaryDeal.title } : null,
+  primaryCompanyId: m.primaryCompanyId,
+  primaryCompany: m.primaryCompany ?? null,
+  linkStatus: m.linkStatus,
+  linkConfidence: m.linkConfidence ? Number(m.linkConfidence) : null,
+  linkMethod: m.linkMethod,
+  // The point of the whole feature: one-click open of recording, summary,
+  // transcript. URLs are nullable — a meeting that hasn't completed yet
+  // (or whose Gemini summary is still cooking) just won't have them.
+  recordingUrl: m.recordingUrl,
+  summaryDocUrl: m.summaryDocUrl,
+  summaryExcerpt: m.summaryExcerpt,
+  transcriptDocUrl: m.transcriptDocUrl,
+  artifactsProcessedAt: m.artifactsProcessedAt?.toISOString() ?? null,
+  artifactsPartial: m.artifactsPartial,
+  attendees: (m.attendees ?? []).map((a) => ({
+    id: a.id,
+    email: a.email,
+    name: a.name,
+    responseStatus: a.responseStatus,
+    isOrganizer: a.isOrganizer,
+    contact: a.contact
+      ? { id: a.contact.id, firstName: a.contact.firstName, lastName: a.contact.lastName }
+      : null,
+    user: a.user ? { id: a.user.id, name: a.user.name } : null,
+  })),
+  createdAt: m.createdAt.toISOString(),
+  updatedAt: m.updatedAt.toISOString(),
 });
 
 export const attachmentDto = (

--- a/apps/api/src/routes/integrations/google.ts
+++ b/apps/api/src/routes/integrations/google.ts
@@ -7,8 +7,11 @@ import { requireUserSession } from '../../auth/middleware.js';
 import { asyncHandler, HttpError } from '../../lib/error.js';
 import { logger } from '../../lib/logger.js';
 import {
+  enqueueGoogleCalendarPull,
   enqueueGoogleContactsPull,
+  ensureGoogleCalendarPullScheduled,
   ensureGoogleContactsPullScheduled,
+  unscheduleGoogleCalendarPull,
   unscheduleGoogleContactsPull,
 } from '../../lib/queue.js';
 import { encryptSecret, decryptSecret } from '../../lib/crypto.js';
@@ -37,7 +40,7 @@ const STATE_TTL_MS = 10 * 60_000;
 // which Google APIs are wired up. Add a string here when you ship the
 // next integration; the OAuth client looks the scope set up.
 const startQuerySchema = z.object({
-  intent: z.enum(['contacts']).default('contacts'),
+  intent: z.enum(['contacts', 'calendar']).default('contacts'),
 });
 
 googleIntegrationRouter.get(
@@ -183,9 +186,9 @@ googleIntegrationRouter.get(
       });
     });
 
-    // Initialise the contacts-sync child row + kick off the initial
-    // import. The contacts intent is the only one wired up today; future
-    // intents (gmail, calendar) will mint their own child rows here.
+    // Initialise the per-integration child row + kick off the initial
+    // pull. Each intent owns its own child table — adding a third
+    // integration (Gmail) lands here as another branch.
     if (state.intent === 'contacts') {
       await prisma.googleContactsSync.upsert({
         where: { googleAccountId: account.id },
@@ -216,6 +219,30 @@ googleIntegrationRouter.get(
           'failed to enqueue initial contacts pull',
         );
       }
+    } else if (state.intent === 'calendar') {
+      await prisma.googleCalendarSync.upsert({
+        where: { googleAccountId: account.id },
+        create: { googleAccountId: account.id },
+        update: {
+          // Reconnecting drops the delta token so the next pull does a
+          // bounded re-list of the lookback window — picks up anything
+          // that happened while the connection was down without us
+          // having to think about state reconciliation.
+          eventsSyncToken: null,
+        },
+      });
+      try {
+        await enqueueGoogleCalendarPull({
+          kind: 'incremental',
+          googleAccountId: account.id,
+        });
+        await ensureGoogleCalendarPullScheduled(account.id);
+      } catch (err) {
+        logger.error(
+          { err, googleAccountId: account.id },
+          'failed to enqueue initial calendar pull',
+        );
+      }
     }
 
     return ok();
@@ -244,6 +271,13 @@ const statusOutSchema = z.object({
       initialImportedCount: z.number(),
     })
     .nullable(),
+  calendar: z
+    .object({
+      enabled: z.boolean(),
+      lastEventsSyncedAt: z.string().nullable(),
+      lastArtifactsSyncedAt: z.string().nullable(),
+    })
+    .nullable(),
 });
 
 googleIntegrationRouter.get(
@@ -251,7 +285,7 @@ googleIntegrationRouter.get(
   asyncHandler(async (req, res) => {
     const account = await prisma.googleAccount.findUnique({
       where: { userId: req.user!.id },
-      include: { contactsSync: true },
+      include: { contactsSync: true, calendarSync: true },
     });
     const out: z.infer<typeof statusOutSchema> = {
       connected: Boolean(account && !account.disabledAt),
@@ -273,6 +307,14 @@ googleIntegrationRouter.get(
             lastPulledAt: account.contactsSync.lastPulledAt?.toISOString() ?? null,
             lastPushedAt: account.contactsSync.lastPushedAt?.toISOString() ?? null,
             initialImportedCount: account.contactsSync.initialImportedCount,
+          }
+        : null,
+      calendar: account?.calendarSync
+        ? {
+            enabled: account.calendarSync.enabled,
+            lastEventsSyncedAt: account.calendarSync.lastEventsSyncedAt?.toISOString() ?? null,
+            lastArtifactsSyncedAt:
+              account.calendarSync.lastArtifactsSyncedAt?.toISOString() ?? null,
           }
         : null,
     };
@@ -306,6 +348,50 @@ googleIntegrationRouter.patch(
       outboundEnabled: updated.outboundEnabled,
       inboundEnabled: updated.inboundEnabled,
     });
+  }),
+);
+
+googleIntegrationRouter.post(
+  '/calendar/resync',
+  asyncHandler(async (req, res) => {
+    const account = await prisma.googleAccount.findUnique({
+      where: { userId: req.user!.id },
+      include: { calendarSync: true },
+    });
+    if (!account || account.disabledAt) {
+      throw new HttpError(409, 'Google account not connected');
+    }
+    if (!account.calendarSync) {
+      throw new HttpError(404, 'No calendar sync configured — reconnect with the calendar intent');
+    }
+    await enqueueGoogleCalendarPull({ kind: 'incremental', googleAccountId: account.id });
+    res.json({ enqueued: 'incremental' });
+  }),
+);
+
+// Drops the Calendar delta token and re-pulls the configured lookback
+// window (currently 90 days). Useful when an account connected before
+// the wider lookback shipped, or when the rep wants to pull in older
+// meetings they need to attach to a deal manually. Idempotent.
+googleIntegrationRouter.post(
+  '/calendar/backfill',
+  asyncHandler(async (req, res) => {
+    const account = await prisma.googleAccount.findUnique({
+      where: { userId: req.user!.id },
+      include: { calendarSync: true },
+    });
+    if (!account || account.disabledAt) {
+      throw new HttpError(409, 'Google account not connected');
+    }
+    if (!account.calendarSync) {
+      throw new HttpError(404, 'No calendar sync configured');
+    }
+    await prisma.googleCalendarSync.update({
+      where: { googleAccountId: account.id },
+      data: { eventsSyncToken: null },
+    });
+    await enqueueGoogleCalendarPull({ kind: 'incremental', googleAccountId: account.id });
+    res.json({ enqueued: 'backfill' });
   }),
 );
 
@@ -368,10 +454,19 @@ googleIntegrationRouter.post(
       where: { googleAccountId: account.id },
       data: { inboundEnabled: false, outboundEnabled: false },
     });
+    await prisma.googleCalendarSync.updateMany({
+      where: { googleAccountId: account.id },
+      data: { enabled: false },
+    });
     try {
       await unscheduleGoogleContactsPull(account.id);
     } catch (err) {
       logger.warn({ err }, 'failed to unschedule google contacts pull');
+    }
+    try {
+      await unscheduleGoogleCalendarPull(account.id);
+    } catch (err) {
+      logger.warn({ err }, 'failed to unschedule google calendar pull');
     }
     invalidateOutboundCache();
     res.json({ disconnected: true });

--- a/apps/api/src/routes/meetings.ts
+++ b/apps/api/src/routes/meetings.ts
@@ -1,0 +1,302 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { prisma } from '../db.js';
+import { requireAuth } from '../auth/middleware.js';
+import { asyncHandler, HttpError } from '../lib/error.js';
+import { meetingDto, taskDto } from '../lib/serialize.js';
+import { enqueueGoogleCalendarArtifacts } from '../lib/queue.js';
+
+// Read + light-write API for meetings. The heavy ingest path (calendar
+// pull + artifact watcher) lives in the worker; everything here is the
+// thin layer the web UI calls to render meeting cards on a deal/contact
+// page and to let the rep correct an auto-link.
+//
+// No create endpoint by design — meetings are only ever materialized
+// from Calendar events. A "log a meeting manually" path could be added
+// later but isn't part of this slice.
+
+export const meetingsRouter = Router();
+meetingsRouter.use(requireAuth);
+
+// Common include shape — mirrors the meetingDto's expected relations.
+const meetingInclude = {
+  organizer: true,
+  attendees: {
+    include: { contact: true, user: true },
+    orderBy: { id: 'asc' as const },
+  },
+  primaryContact: true,
+  primaryDeal: { select: { id: true, title: true } },
+  primaryCompany: { select: { id: true, name: true } },
+} as const;
+
+const listQuerySchema = z.object({
+  dealId: z.coerce.number().int().positive().optional(),
+  contactId: z.coerce.number().int().positive().optional(),
+  companyId: z.coerce.number().int().positive().optional(),
+  // 'all' | 'past' | 'upcoming'. Default 'all' — the deal page wants
+  // both for the timeline view; the dashboard's "next meeting" widget
+  // would filter to 'upcoming'.
+  when: z.enum(['all', 'past', 'upcoming']).default('all'),
+  // Filter to meetings that aren't firmly attached to anything yet.
+  // Powers the "Connect meeting" dialog on the deal page — by default
+  // the dialog only shows unlinked / suggested meetings (rare to
+  // re-attach a confirmed one), with an "Show all" toggle that drops
+  // this filter.
+  unlinkedOnly: z
+    .union([z.literal('true'), z.literal('false'), z.boolean()])
+    .optional()
+    .transform((v) => v === true || v === 'true'),
+  // Free-text title search — case-insensitive substring on Meeting.title.
+  // Cheap because the candidate set is small (an account's meetings
+  // within the 90-day lookback).
+  q: z.string().min(1).max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+});
+
+meetingsRouter.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const q = listQuerySchema.parse(req.query);
+    const now = new Date();
+    const where: import('@prisma/client').Prisma.MeetingWhereInput = {
+      deletedAt: null,
+    };
+    if (q.dealId != null) where.primaryDealId = q.dealId;
+    if (q.contactId != null) where.primaryContactId = q.contactId;
+    if (q.companyId != null) where.primaryCompanyId = q.companyId;
+    if (q.when === 'past') where.scheduledEnd = { lt: now };
+    else if (q.when === 'upcoming') where.scheduledStart = { gte: now };
+    if (q.unlinkedOnly) {
+      // 'unlinked' (matcher found nothing) or 'suggested' (matcher had a
+      // weak guess pending review). Confirmed/rejected stay out of the
+      // dialog by default.
+      where.linkStatus = { in: ['unlinked', 'suggested'] };
+    }
+    if (q.q) {
+      where.title = { contains: q.q, mode: 'insensitive' };
+    }
+    const meetings = await prisma.meeting.findMany({
+      where,
+      include: meetingInclude,
+      orderBy: { scheduledStart: 'desc' },
+      take: q.limit,
+    });
+    res.json({ meetings: meetings.map(meetingDto) });
+  }),
+);
+
+meetingsRouter.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const id = Number(req.params.id);
+    const meeting = await prisma.meeting.findUnique({
+      where: { id },
+      include: meetingInclude,
+    });
+    if (!meeting || meeting.deletedAt) throw new HttpError(404, 'Meeting not found');
+    res.json({ meeting: meetingDto(meeting) });
+  }),
+);
+
+const linkUpdateSchema = z
+  .object({
+    primaryContactId: z.number().int().positive().nullable().optional(),
+    primaryDealId: z.number().int().positive().nullable().optional(),
+    primaryCompanyId: z.number().int().positive().nullable().optional(),
+    // Allowed transitions: confirmed (manual link or accept), rejected
+    // (clear the suggested link). The matcher writes the rest; the API
+    // never accepts 'unlinked' or 'suggested' from the wire because
+    // those are matcher-driven states.
+    linkStatus: z.enum(['confirmed', 'rejected']),
+  })
+  .refine(
+    (d) =>
+      d.linkStatus === 'rejected' ||
+      d.primaryContactId != null ||
+      d.primaryDealId != null ||
+      d.primaryCompanyId != null,
+    { message: 'A confirmed link must point at a contact, deal, or company' },
+  );
+
+// Accept-or-reject the auto-link suggestion, or set a manual link. This
+// is what the meeting card's "Looks right" / "Fix this" / "Pick a deal"
+// buttons hit. We re-write the audit trail with outcome=overridden so a
+// later analytics pass can tune the matcher's confidence ladder.
+meetingsRouter.patch(
+  '/:id/link',
+  asyncHandler(async (req, res) => {
+    const id = Number(req.params.id);
+    const body = linkUpdateSchema.parse(req.body);
+    const meeting = await prisma.$transaction(async (tx) => {
+      const existing = await tx.meeting.findUnique({ where: { id } });
+      if (!existing || existing.deletedAt) throw new HttpError(404, 'Meeting not found');
+
+      // Pull the latest audit row and mark its outcome based on the
+      // direction of the user's action. Doesn't delete the row — the
+      // history matters.
+      const lastAudit = await tx.meetingLinkAudit.findFirst({
+        where: { meetingId: id },
+        orderBy: { attemptedAt: 'desc' },
+      });
+      if (lastAudit && body.linkStatus === 'rejected') {
+        await tx.meetingLinkAudit.update({
+          where: { id: lastAudit.id },
+          data: { outcome: 'rejected' },
+        });
+      } else if (lastAudit) {
+        // Confirmed via the manual flow — was the matcher right? If the
+        // user picked something different, mark overridden.
+        const matcherRight =
+          lastAudit.chosenContactId === (body.primaryContactId ?? null) &&
+          lastAudit.chosenDealId === (body.primaryDealId ?? null) &&
+          lastAudit.chosenCompanyId === (body.primaryCompanyId ?? null);
+        await tx.meetingLinkAudit.update({
+          where: { id: lastAudit.id },
+          data: { outcome: matcherRight ? 'accepted' : 'overridden' },
+        });
+      }
+
+      // Hydrate missing relations from the deal when the caller only
+      // supplied a dealId (the Connect Meeting dialog hits this path —
+      // the rep picks a deal, we infer the contact + company). Cheaper
+      // for the client than making it remember the deal's relations,
+      // and keeps the matcher's invariant ("a meeting on a deal also
+      // points at the deal's contact / company") intact for human-
+      // driven links too.
+      let primaryContactId = body.primaryContactId ?? null;
+      let primaryCompanyId = body.primaryCompanyId ?? null;
+      if (
+        body.linkStatus === 'confirmed' &&
+        body.primaryDealId != null &&
+        primaryContactId == null &&
+        primaryCompanyId == null
+      ) {
+        const deal = await tx.deal.findUnique({
+          where: { id: body.primaryDealId },
+          select: { primaryContactId: true, companyId: true },
+        });
+        if (deal) {
+          primaryContactId = deal.primaryContactId;
+          primaryCompanyId = deal.companyId;
+        }
+      }
+
+      // For a manual confirm we record it as a fresh manual audit row
+      // too — keeps the lineage clean (matcher attempt, then human
+      // override). Skip on rejection to avoid log noise.
+      if (body.linkStatus === 'confirmed') {
+        await tx.meetingLinkAudit.create({
+          data: {
+            meetingId: id,
+            method: 'manual',
+            candidates: [],
+            chosenContactId: primaryContactId,
+            chosenDealId: body.primaryDealId ?? null,
+            chosenCompanyId: primaryCompanyId,
+            confidence: 1,
+            outcome: 'accepted',
+          },
+        });
+      }
+
+      return tx.meeting.update({
+        where: { id },
+        data: {
+          linkStatus: body.linkStatus,
+          // When rejecting, blank the primary fields so the meeting
+          // card stops claiming a wrong link. Audit row preserves the
+          // history.
+          primaryContactId: body.linkStatus === 'rejected' ? null : primaryContactId,
+          primaryDealId: body.linkStatus === 'rejected' ? null : body.primaryDealId ?? null,
+          primaryCompanyId: body.linkStatus === 'rejected' ? null : primaryCompanyId,
+          linkConfidence: body.linkStatus === 'confirmed' ? 1 : null,
+          linkMethod: body.linkStatus === 'confirmed' ? 'manual' : null,
+          linkedAt: body.linkStatus === 'confirmed' ? new Date() : null,
+          linkedByUserId: body.linkStatus === 'confirmed' ? req.user!.id : null,
+        },
+        include: meetingInclude,
+      });
+    });
+    res.json({ meeting: meetingDto(meeting) });
+  }),
+);
+
+// Accept / reject auto-extracted action items. These are tasks with
+// status='pending_review' that came out of a Gemini summary — the rep
+// confirms them (→ pending in their queue) or dismisses them
+// (→ dismissed, kept for tuning signal). Editing the title/due/assignee
+// before accepting goes through the regular tasks PATCH.
+const taskActionSchema = z.object({
+  action: z.enum(['accept', 'dismiss']),
+});
+
+meetingsRouter.post(
+  '/:id/tasks/:taskId/action',
+  asyncHandler(async (req, res) => {
+    const meetingId = Number(req.params.id);
+    const taskId = Number(req.params.taskId);
+    const body = taskActionSchema.parse(req.body);
+    const task = await prisma.task.findUnique({ where: { id: taskId } });
+    if (!task || task.sourceMeetingId !== meetingId) {
+      throw new HttpError(404, 'Action item not found on this meeting');
+    }
+    const updated = await prisma.task.update({
+      where: { id: taskId },
+      data: { status: body.action === 'accept' ? 'pending' : 'dismissed' },
+      include: { assignee: true, deal: { select: { id: true, title: true } } },
+    });
+    res.json({ task: taskDto(updated) });
+  }),
+);
+
+// Manual artifact refresh. Resets the meeting's
+// `artifactsProcessedAt` / `artifactsPartial` so the watcher will
+// re-attempt the recording / summary / transcript fetch on its next
+// run, then enqueues an immediate artifacts run for the source account
+// so the rep doesn't have to wait for the cron tick. Useful when:
+//   - The auto-fetch missed an artifact (Drive search couldn't match
+//     the title pattern, Meet API hadn't propagated yet, etc.)
+//   - A meeting was backfilled and pre-disqualified (older bug — fixed
+//     but legacy rows remain)
+//   - A summary / transcript was edited and we want to re-parse
+meetingsRouter.post(
+  '/:id/refresh-artifacts',
+  asyncHandler(async (req, res) => {
+    const id = Number(req.params.id);
+    const meeting = await prisma.meeting.findUnique({
+      where: { id },
+      select: { id: true, sourceAccountId: true, deletedAt: true },
+    });
+    if (!meeting || meeting.deletedAt) throw new HttpError(404, 'Meeting not found');
+    if (meeting.sourceAccountId == null) {
+      throw new HttpError(409, 'No connected calendar account on this meeting');
+    }
+    await prisma.meeting.update({
+      where: { id },
+      data: { artifactsProcessedAt: null, artifactsPartial: false },
+    });
+    await enqueueGoogleCalendarArtifacts({ googleAccountId: meeting.sourceAccountId });
+    res.json({ enqueued: true });
+  }),
+);
+
+// Pending-review action-items inbox for a deal. Used by the deal page's
+// "Action items from meetings — needs review" panel. Returns tasks the
+// rep should triage; cleanly excludes the regular task queue.
+meetingsRouter.get(
+  '/inbox/by-deal/:dealId',
+  asyncHandler(async (req, res) => {
+    const dealId = Number(req.params.dealId);
+    const tasks = await prisma.task.findMany({
+      where: {
+        dealId,
+        status: 'pending_review',
+        sourceMeetingId: { not: null },
+      },
+      include: { assignee: true, deal: { select: { id: true, title: true } } },
+      orderBy: { createdAt: 'desc' },
+    });
+    res.json({ tasks: tasks.map(taskDto) });
+  }),
+);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -20,6 +20,7 @@ import { contactsRouter } from './routes/contacts.js';
 import { dealsRouter } from './routes/deals.js';
 import { tasksRouter } from './routes/tasks.js';
 import { notesRouter } from './routes/notes.js';
+import { meetingsRouter } from './routes/meetings.js';
 import { uploadsRouter } from './routes/uploads.js';
 import { searchRouter } from './routes/search.js';
 import { dashboardRouter } from './routes/dashboard.js';
@@ -99,6 +100,7 @@ export function buildApp() {
   app.use('/api/deals', dealsRouter);
   app.use('/api/tasks', tasksRouter);
   app.use('/api/notes', notesRouter);
+  app.use('/api/meetings', meetingsRouter);
   app.use('/api/uploads', uploadsRouter);
   app.use('/api/search', searchRouter);
   app.use('/api/dashboard', dashboardRouter);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,6 +13,7 @@ import { CompanyDetail } from '@/pages/companies/CompanyDetail';
 import { Contacts } from '@/pages/contacts/Contacts';
 import { ContactDetail } from '@/pages/contacts/ContactDetail';
 import { Tasks } from '@/pages/tasks/Tasks';
+import { Meetings } from '@/pages/meetings/Meetings';
 import { Reports } from '@/pages/Reports';
 import { SettingsLayout } from '@/pages/settings/SettingsLayout';
 import { StagesCard } from '@/pages/settings/StagesCard';
@@ -50,6 +51,7 @@ export function App() {
         <Route path="contacts" element={<Contacts />} />
         <Route path="contacts/:id" element={<ContactDetail />} />
         <Route path="tasks" element={<Tasks />} />
+        <Route path="meetings" element={<Meetings />} />
         <Route path="reports" element={<Reports />} />
         <Route path="settings" element={<SettingsLayout />}>
           <Route index element={<Navigate to="profile" replace />} />

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@ import { NavLink, useLocation } from 'react-router-dom';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {
   Building2, CalendarRange, Cog, Contact2, KanbanSquare, LayoutDashboard, ListChecks,
-  PieChart, X,
+  PieChart, Video, X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -14,6 +14,7 @@ const NAV = [
   { to: '/companies', label: 'Companies', icon: Building2 },
   { to: '/contacts', label: 'Contacts', icon: Contact2 },
   { to: '/tasks', label: 'Tasks', icon: CalendarRange },
+  { to: '/meetings', label: 'Meetings', icon: Video },
   { to: '/reports', label: 'Reports', icon: PieChart },
 ];
 

--- a/apps/web/src/components/meetings/ConnectMeetingDialog.tsx
+++ b/apps/web/src/components/meetings/ConnectMeetingDialog.tsx
@@ -1,0 +1,206 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Search, Sparkles, Video } from 'lucide-react';
+import { toast } from 'sonner';
+import { api, ApiError } from '@/lib/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import type { MeetingDto } from '@/types';
+
+// Connect Meeting dialog. Used from the deal page Meetings tab when the
+// auto-link matcher missed a meeting (title-based disambiguation can't
+// catch every "30min with Dispatch Scout" naming convention). The rep
+// picks a meeting from a list of candidates; we link it via the existing
+// PATCH /meetings/:id/link endpoint with the deal id, and the API
+// hydrates the contact / company from the deal automatically.
+//
+// Default candidate set is "unlinked or suggested" — confirmed-elsewhere
+// meetings are out by default so the dialog stays focused. The "Show all
+// meetings" toggle drops that filter for the rare cases where a rep
+// needs to re-attach.
+
+interface Props {
+  dealId: number;
+  dealTitle: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ConnectMeetingDialog({ dealId, dealTitle, open, onOpenChange }: Props) {
+  const qc = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [showAll, setShowAll] = useState(false);
+
+  // Pull a fresh candidate list each time the dialog opens. Don't bother
+  // debouncing the search input — the result set is small enough that
+  // we filter client-side; only refetch when the show-all toggle flips.
+  const { data, isLoading } = useQuery({
+    queryKey: ['meetings', 'candidates', { showAll }],
+    queryFn: () => {
+      const params = new URLSearchParams();
+      if (!showAll) params.set('unlinkedOnly', 'true');
+      params.set('limit', '100');
+      return api.get<{ meetings: MeetingDto[] }>(`/meetings?${params.toString()}`);
+    },
+    enabled: open,
+  });
+
+  const filtered = useMemo(() => {
+    const list = data?.meetings ?? [];
+    if (!search.trim()) return list;
+    const s = search.trim().toLowerCase();
+    return list.filter((m) => m.title.toLowerCase().includes(s));
+  }, [data, search]);
+
+  const link = useMutation({
+    mutationFn: (meetingId: number) =>
+      api.patch<{ meeting: MeetingDto }>(`/meetings/${meetingId}/link`, {
+        linkStatus: 'confirmed',
+        primaryDealId: dealId,
+      }),
+    onSuccess: () => {
+      toast.success('Meeting linked to deal');
+      // The deal page's Meetings tab + the candidates list both need
+      // refetching. Invalidate broadly — the keys are scoped enough
+      // that only the meetings UI repaints.
+      void qc.invalidateQueries({ queryKey: ['meetings'] });
+      void qc.invalidateQueries({ queryKey: ['meeting-inbox', dealId] });
+      onOpenChange(false);
+    },
+    onError: (e) => toast.error(formatErr(e, 'Could not link meeting')),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Connect a meeting to {dealTitle}</DialogTitle>
+          <DialogDescription>
+            Pick a meeting to attach. Recording, summary, and transcript
+            links (when available) come along automatically.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              autoFocus
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Filter by title…"
+              className="pl-8"
+            />
+          </div>
+
+          <div className="flex items-center justify-between rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-xs">
+            <Label htmlFor="show-all-meetings" className="cursor-pointer">
+              Show meetings already linked to other deals
+            </Label>
+            <Switch
+              id="show-all-meetings"
+              checked={showAll}
+              onCheckedChange={setShowAll}
+            />
+          </div>
+
+          <div className="max-h-[50vh] space-y-1 overflow-y-auto">
+            {isLoading ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">Loading…</p>
+            ) : filtered.length === 0 ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">
+                {search
+                  ? 'No meetings match that search.'
+                  : showAll
+                  ? 'No meetings ingested yet.'
+                  : 'No unlinked meetings. Toggle "Show meetings already linked" to widen the list.'}
+              </p>
+            ) : (
+              filtered.map((m) => (
+                <CandidateRow
+                  key={m.id}
+                  meeting={m}
+                  onPick={() => link.mutate(m.id)}
+                  busy={link.isPending && link.variables === m.id}
+                />
+              ))
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CandidateRow({
+  meeting,
+  onPick,
+  busy,
+}: {
+  meeting: MeetingDto;
+  onPick: () => void;
+  busy: boolean;
+}) {
+  const start = new Date(meeting.scheduledStart);
+  const past = start.getTime() < Date.now();
+  return (
+    <button
+      type="button"
+      onClick={onPick}
+      disabled={busy}
+      className="flex w-full flex-col gap-1 rounded-md border border-border/60 px-3 py-2 text-left transition hover:border-foreground/40 hover:bg-muted disabled:opacity-50"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium">{meeting.title}</span>
+        <span className="text-xs text-muted-foreground">{start.toLocaleString()}</span>
+        {meeting.recordingUrl ? (
+          <Badge variant="outline" className="border-border/60 text-[10px]">
+            <Video className="mr-1 h-3 w-3" /> Recording
+          </Badge>
+        ) : null}
+        {meeting.summaryDocUrl ? (
+          <Badge variant="outline" className="border-border/60 text-[10px]">
+            <Sparkles className="mr-1 h-3 w-3" /> Summary
+          </Badge>
+        ) : null}
+        {meeting.linkStatus === 'confirmed' && meeting.primaryDeal ? (
+          <Badge variant="outline" className="border-emerald-500/40 text-[10px] text-emerald-600 dark:text-emerald-400">
+            Linked to {meeting.primaryDeal.title}
+          </Badge>
+        ) : null}
+      </div>
+      <div className="text-xs text-muted-foreground">
+        {past ? 'Past' : 'Upcoming'} · {meeting.attendees.length} attendee
+        {meeting.attendees.length === 1 ? '' : 's'}
+        {meeting.summaryExcerpt ? ` · ${truncate(meeting.summaryExcerpt, 100)}` : ''}
+      </div>
+    </button>
+  );
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}
+
+function formatErr(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) return e.message;
+  if (e instanceof Error) return e.message;
+  return fallback;
+}

--- a/apps/web/src/components/meetings/MeetingsPanel.tsx
+++ b/apps/web/src/components/meetings/MeetingsPanel.tsx
@@ -1,0 +1,448 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  FileText,
+  Link2Off,
+  Plus,
+  RefreshCw,
+  Sparkles,
+  Video,
+  X,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { api, ApiError } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { MeetingDto, TaskDto } from '@/types';
+import { relativeTime } from '@/lib/utils';
+import { ConnectMeetingDialog } from './ConnectMeetingDialog';
+
+// Meetings panel — embedded on deal, contact, and company detail pages.
+// The headline interaction is the three artifact buttons on each meeting
+// card: open recording, open Gemini summary doc, open transcript. Anything
+// missing renders as a disabled placeholder rather than vanishing, so the
+// rep can tell at a glance whether Gemini is still cooking vs. there's
+// genuinely no recording.
+//
+// Scope filters: pass exactly one of dealId / contactId / companyId. The
+// API accepts more, but the panel is deliberately single-scope so the
+// "from meeting" badges line up with the card the user is on.
+
+interface PanelProps {
+  dealId?: number;
+  contactId?: number;
+  companyId?: number;
+  // Title of the deal the panel is rendered for. Used in the Connect
+  // Meeting dialog header so the rep can verify they're attaching to
+  // the deal they're looking at. Only meaningful when dealId is set.
+  dealTitle?: string;
+  // When the panel sits on a deal page, also surface the action-items
+  // inbox above the meeting list. On contact / company panels we hide
+  // it — those don't have a single deal to attribute the inbox to.
+  showInbox?: boolean;
+}
+
+export function MeetingsPanel(props: PanelProps) {
+  const qc = useQueryClient();
+  const [connectOpen, setConnectOpen] = useState(false);
+  // Key only on the scope ids — display-only props like `dealTitle` and
+  // `showInbox` don't change the API result and would otherwise force a
+  // refetch on parent re-renders that produced an equivalent prop bundle
+  // with a fresh object identity.
+  const queryKey = [
+    'meetings',
+    { dealId: props.dealId ?? null, contactId: props.contactId ?? null, companyId: props.companyId ?? null },
+  ] as const;
+  const { data, isLoading } = useQuery({
+    queryKey,
+    queryFn: () => {
+      const params = new URLSearchParams();
+      if (props.dealId != null) params.set('dealId', String(props.dealId));
+      if (props.contactId != null) params.set('contactId', String(props.contactId));
+      if (props.companyId != null) params.set('companyId', String(props.companyId));
+      return api.get<{ meetings: MeetingDto[] }>(`/meetings?${params.toString()}`);
+    },
+  });
+
+  const inboxEnabled = props.showInbox && props.dealId != null;
+  const inbox = useQuery({
+    queryKey: ['meeting-inbox', props.dealId],
+    queryFn: () =>
+      api.get<{ tasks: TaskDto[] }>(`/meetings/inbox/by-deal/${props.dealId}`),
+    enabled: !!inboxEnabled,
+  });
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading meetings…</p>;
+  }
+  const meetings = data?.meetings ?? [];
+
+  const onChanged = () => {
+    void qc.invalidateQueries({ queryKey });
+    if (inboxEnabled) {
+      void qc.invalidateQueries({ queryKey: ['meeting-inbox', props.dealId] });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {props.dealId != null ? (
+        <div className="flex justify-end">
+          <Button size="sm" variant="outline" onClick={() => setConnectOpen(true)}>
+            <Plus className="mr-1 h-3.5 w-3.5" /> Connect meeting
+          </Button>
+        </div>
+      ) : null}
+
+      {inboxEnabled && (inbox.data?.tasks.length ?? 0) > 0 ? (
+        <ActionItemsInbox dealId={props.dealId!} tasks={inbox.data!.tasks} />
+      ) : null}
+
+      {meetings.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No meetings yet.</p>
+      ) : (
+        <div className="space-y-3">
+          {meetings.map((m) => (
+            <MeetingCard key={m.id} meeting={m} onChanged={onChanged} />
+          ))}
+        </div>
+      )}
+
+      {props.dealId != null ? (
+        <ConnectMeetingDialog
+          dealId={props.dealId}
+          dealTitle={props.dealTitle ?? 'this deal'}
+          open={connectOpen}
+          onOpenChange={setConnectOpen}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function MeetingCard({
+  meeting,
+  onChanged,
+}: {
+  meeting: MeetingDto;
+  onChanged: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const start = new Date(meeting.scheduledStart);
+  const isUpcoming = start.getTime() > Date.now();
+  const status = meeting.status;
+  const linkStatus = meeting.linkStatus;
+
+  const reject = useMutation({
+    mutationFn: () =>
+      api.patch<{ meeting: MeetingDto }>(`/meetings/${meeting.id}/link`, {
+        linkStatus: 'rejected',
+      }),
+    onSuccess: () => {
+      toast.success('Suggestion rejected');
+      onChanged();
+    },
+    onError: (e) => toast.error(formatErr(e, 'Could not reject')),
+  });
+
+  const accept = useMutation({
+    mutationFn: () =>
+      api.patch<{ meeting: MeetingDto }>(`/meetings/${meeting.id}/link`, {
+        linkStatus: 'confirmed',
+        primaryContactId: meeting.primaryContactId,
+        primaryDealId: meeting.primaryDealId,
+        primaryCompanyId: meeting.primaryCompanyId,
+      }),
+    onSuccess: () => {
+      toast.success('Meeting linked');
+      onChanged();
+    },
+    onError: (e) => toast.error(formatErr(e, 'Could not confirm')),
+  });
+
+  const refresh = useMutation({
+    mutationFn: () =>
+      api.post<{ enqueued: boolean }>(`/meetings/${meeting.id}/refresh-artifacts`),
+    onSuccess: () => {
+      toast.success('Refresh enqueued — checking for recording, summary, transcript');
+      // Give the worker a moment, then refetch so the URLs appear if they
+      // landed quickly. Not a guarantee — Drive search + Doc fetch can
+      // take seconds.
+      setTimeout(onChanged, 2_000);
+    },
+    onError: (e) => toast.error(formatErr(e, 'Could not refresh')),
+  });
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 pt-4">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-sm font-medium">{meeting.title}</h3>
+              {linkStatus === 'suggested' ? (
+                <Badge variant="outline" className="border-amber-500/40 text-amber-600 dark:text-amber-400">
+                  Needs review
+                </Badge>
+              ) : linkStatus === 'confirmed' ? (
+                <Badge variant="outline" className="border-emerald-500/40 text-emerald-600 dark:text-emerald-400">
+                  Linked
+                </Badge>
+              ) : null}
+              {meeting.artifactsPartial ? (
+                <Badge
+                  variant="outline"
+                  className="border-muted-foreground/30 text-xs text-muted-foreground"
+                >
+                  Partial artifacts
+                </Badge>
+              ) : null}
+            </div>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {start.toLocaleString()} · {status}
+            </p>
+            {meeting.summaryExcerpt ? (
+              <p className="mt-2 text-sm text-foreground/90 line-clamp-3">
+                <Sparkles className="mr-1 inline h-3.5 w-3.5 text-blue-500" />
+                {meeting.summaryExcerpt}
+              </p>
+            ) : null}
+          </div>
+
+          {isUpcoming ? null : (
+            <ArtifactButtons meeting={meeting} />
+          )}
+        </div>
+
+        {linkStatus === 'suggested' ? (
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" variant="outline" onClick={() => accept.mutate()} disabled={accept.isPending}>
+              <Check className="mr-1 h-3.5 w-3.5" /> Looks right
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => reject.mutate()} disabled={reject.isPending}>
+              <Link2Off className="mr-1 h-3.5 w-3.5" /> Not this one
+            </Button>
+          </div>
+        ) : linkStatus === 'confirmed' ? (
+          <Button size="sm" variant="ghost" onClick={() => reject.mutate()} disabled={reject.isPending}>
+            <Link2Off className="mr-1 h-3.5 w-3.5" /> Unlink
+          </Button>
+        ) : null}
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {expanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            {expanded ? 'Hide' : 'Show'} attendees
+          </button>
+          {!isUpcoming ? (
+            <button
+              onClick={() => refresh.mutate()}
+              disabled={refresh.isPending}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+              title="Re-check Drive for the recording, summary, and transcript"
+            >
+              <RefreshCw className={`h-3 w-3 ${refresh.isPending ? 'animate-spin' : ''}`} />
+              {refresh.isPending ? 'Refreshing…' : 'Refresh artifacts'}
+            </button>
+          ) : null}
+        </div>
+
+        {expanded ? (
+          <div className="rounded-md border bg-muted/30 p-2 text-xs">
+            {meeting.attendees.length === 0 ? (
+              <p className="text-muted-foreground">No attendees recorded.</p>
+            ) : (
+              <ul className="space-y-1">
+                {meeting.attendees.map((a) => (
+                  <li key={a.id} className="flex items-center gap-2">
+                    <span>{a.name ?? a.email}</span>
+                    {a.contact ? (
+                      <span className="text-muted-foreground">
+                        ↔ contact #{a.contact.id}
+                      </span>
+                    ) : null}
+                    {a.user ? (
+                      <span className="text-muted-foreground">(internal)</span>
+                    ) : null}
+                    {a.responseStatus ? (
+                      <span className="ml-auto text-muted-foreground">{a.responseStatus}</span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+// The three big buttons. This is the feature: one click → Drive opens
+// the recording / summary / transcript in a new tab. Disabled state for
+// missing artifacts intentionally still renders so the rep can tell
+// "this meeting just hasn't produced one yet."
+function ArtifactButtons({ meeting }: { meeting: MeetingDto }) {
+  return (
+    <div className="flex shrink-0 flex-wrap gap-1.5">
+      <ArtifactButton
+        href={meeting.recordingUrl}
+        label="Recording"
+        icon={<Video className="h-3.5 w-3.5" />}
+      />
+      <ArtifactButton
+        href={meeting.summaryDocUrl}
+        label="Summary"
+        icon={<Sparkles className="h-3.5 w-3.5" />}
+      />
+      <ArtifactButton
+        href={meeting.transcriptDocUrl}
+        label="Transcript"
+        icon={<FileText className="h-3.5 w-3.5" />}
+      />
+    </div>
+  );
+}
+
+function ArtifactButton({
+  href,
+  label,
+  icon,
+}: {
+  href: string | null;
+  label: string;
+  icon: React.ReactNode;
+}) {
+  if (!href) {
+    return (
+      <span
+        className="inline-flex select-none items-center gap-1 rounded-md border border-dashed border-border/60 px-2 py-1 text-xs text-muted-foreground/70"
+        title={`${label} not available yet`}
+      >
+        {icon}
+        {label}
+      </span>
+    );
+  }
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 rounded-md border border-border/70 bg-background px-2 py-1 text-xs font-medium hover:border-foreground/40 hover:bg-muted"
+    >
+      {icon}
+      {label}
+    </a>
+  );
+}
+
+function ActionItemsInbox({
+  dealId,
+  tasks,
+}: {
+  dealId: number;
+  tasks: TaskDto[];
+}) {
+  const qc = useQueryClient();
+  const decide = useMutation({
+    mutationFn: ({
+      meetingId,
+      taskId,
+      action,
+    }: {
+      meetingId: number;
+      taskId: number;
+      action: 'accept' | 'dismiss';
+    }) =>
+      api.post<{ task: TaskDto }>(`/meetings/${meetingId}/tasks/${taskId}/action`, { action }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['meeting-inbox', dealId] });
+      void qc.invalidateQueries({ queryKey: ['deal', dealId] });
+    },
+    onError: (e) => toast.error(formatErr(e, 'Could not update action item')),
+  });
+
+  return (
+    <Card className="border-amber-500/30">
+      <CardContent className="space-y-3 pt-4">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <AlertCircle className="h-4 w-4 text-amber-500" />
+          Action items from meetings — {tasks.length} need{tasks.length === 1 ? 's' : ''} review
+        </div>
+        <ul className="space-y-2">
+          {tasks.map((t) => (
+            <li
+              key={t.id}
+              className="flex flex-wrap items-center gap-2 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-sm"
+            >
+              <span className="min-w-0 flex-1">
+                {t.customerCommitment ? (
+                  <Badge
+                    variant="outline"
+                    className="mr-2 border-purple-500/40 text-xs text-purple-600 dark:text-purple-400"
+                  >
+                    Customer
+                  </Badge>
+                ) : null}
+                {t.title}
+                {t.assignee ? (
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    → {t.assignee.name}
+                  </span>
+                ) : null}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {t.createdAt ? relativeTime(t.createdAt) : null}
+              </span>
+              <div className="flex gap-1">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    decide.mutate({
+                      meetingId: t.sourceMeetingId!,
+                      taskId: t.id,
+                      action: 'accept',
+                    })
+                  }
+                  disabled={decide.isPending}
+                >
+                  <Check className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() =>
+                    decide.mutate({
+                      meetingId: t.sourceMeetingId!,
+                      taskId: t.id,
+                      action: 'dismiss',
+                    })
+                  }
+                  disabled={decide.isPending}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatErr(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) return e.message;
+  if (e instanceof Error) return e.message;
+  return fallback;
+}

--- a/apps/web/src/pages/contacts/ContactDetail.tsx
+++ b/apps/web/src/pages/contacts/ContactDetail.tsx
@@ -16,6 +16,7 @@ import { CustomFieldsReadCard } from '@/components/customFields/CustomFieldsRead
 import { TagChip } from '@/components/tags/TagChip';
 import { TagEditPopover } from '@/components/tags/TagEditPopover';
 import { ContactEditDialog } from './ContactEditDialog';
+import { MeetingsPanel } from '@/components/meetings/MeetingsPanel';
 
 export function ContactDetail() {
   const { id } = useParams<{ id: string }>();
@@ -256,6 +257,15 @@ export function ContactDetail() {
                   Not the primary contact on any deals.
                 </p>
               ) : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Meetings</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <MeetingsPanel contactId={contactId} />
             </CardContent>
           </Card>
         </div>

--- a/apps/web/src/pages/deals/DealDetail.tsx
+++ b/apps/web/src/pages/deals/DealDetail.tsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
-  ArrowLeft, Calendar, Check, FileText, MoreVertical, Paperclip, Pencil, Pen, Plus, Trash2,
+  ArrowLeft, Calendar, Check, FileText, MoreVertical, Paperclip, Pencil, Pen, Plus, Trash2, Video,
 } from 'lucide-react';
+import { MeetingsPanel } from '@/components/meetings/MeetingsPanel';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -182,6 +183,7 @@ export function DealDetail() {
             <TabsList>
               <TabsTrigger value="notes"><FileText className="mr-1 h-3.5 w-3.5" /> Notes ({data.notes.length})</TabsTrigger>
               <TabsTrigger value="tasks"><Check className="mr-1 h-3.5 w-3.5" /> Tasks ({data.tasks.length})</TabsTrigger>
+              <TabsTrigger value="meetings"><Video className="mr-1 h-3.5 w-3.5" /> Meetings</TabsTrigger>
               <TabsTrigger value="files"><Paperclip className="mr-1 h-3.5 w-3.5" /> Files ({data.attachments.length})</TabsTrigger>
               <TabsTrigger value="activity"><Pencil className="mr-1 h-3.5 w-3.5" /> Activity</TabsTrigger>
             </TabsList>
@@ -203,6 +205,10 @@ export function DealDetail() {
               {data.tasks.map((t) => <TaskRow key={t.id} task={t} dealId={dealId} />)}
               {data.tasks.length === 0 ? <p className="text-sm text-muted-foreground">No tasks yet.</p> : null}
             </div>
+          </TabsContent>
+
+          <TabsContent value="meetings" className="space-y-3">
+            <MeetingsPanel dealId={dealId} dealTitle={deal.title} showInbox />
           </TabsContent>
 
           <TabsContent value="files" className="space-y-3">

--- a/apps/web/src/pages/meetings/Meetings.tsx
+++ b/apps/web/src/pages/meetings/Meetings.tsx
@@ -1,0 +1,304 @@
+import { useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import {
+  Calendar as CalendarIcon,
+  FileText,
+  ListChecks,
+  Search,
+  Sparkles,
+  Video,
+} from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Badge } from '@/components/ui/badge';
+import { api } from '@/lib/api';
+import type { MeetingDto } from '@/types';
+
+// Top-level Meetings page — paired with /tasks. Two views:
+//   - List (default): a flat sortable table of recent meetings, with
+//     the three artifact buttons inline so the rep can hop straight to
+//     the recording / summary / transcript.
+//   - Calendar: a month/week grid that pins each meeting at its start
+//     time. Clicking a meeting opens its primary deal page (where the
+//     full detail view lives) — same pattern as the Tasks calendar.
+//
+// We deliberately don't show every meeting in the workspace — the
+// /api/meetings endpoint already caps results and applies tenant scope.
+// 100 here is the working set you'd actually want to see.
+
+export function Meetings() {
+  const [tab, setTab] = useState('list');
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Meetings</h1>
+        <p className="text-sm text-muted-foreground">
+          Calendar events synced from Google. Recording, Gemini summary, and
+          transcript links land here automatically once Meet finishes
+          processing the call.
+        </p>
+      </div>
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList>
+          <TabsTrigger value="list">
+            <ListChecks className="mr-1 h-3.5 w-3.5" /> List
+          </TabsTrigger>
+          <TabsTrigger value="calendar">
+            <CalendarIcon className="mr-1 h-3.5 w-3.5" /> Calendar
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="list">
+          <MeetingsList />
+        </TabsContent>
+        <TabsContent value="calendar">
+          <MeetingsCalendar />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function MeetingsList() {
+  const [search, setSearch] = useState('');
+  const { data, isLoading } = useQuery({
+    queryKey: ['meetings', 'all'],
+    queryFn: () =>
+      api.get<{ meetings: MeetingDto[] }>('/meetings?limit=100'),
+  });
+
+  const filtered = useMemo(() => {
+    const list = data?.meetings ?? [];
+    if (!search.trim()) return list;
+    const s = search.trim().toLowerCase();
+    return list.filter((m) => {
+      if (m.title.toLowerCase().includes(s)) return true;
+      if (m.primaryDeal?.title.toLowerCase().includes(s)) return true;
+      if (m.primaryCompany?.name.toLowerCase().includes(s)) return true;
+      return m.attendees.some((a) =>
+        (a.name ?? a.email).toLowerCase().includes(s),
+      );
+    });
+  }, [data, search]);
+
+  return (
+    <div className="space-y-3">
+      <div className="relative max-w-md">
+        <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Filter by title, deal, company, or attendee…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-8"
+        />
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : filtered.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {search
+            ? 'No meetings match that filter.'
+            : 'No meetings yet. Connect Google Calendar from Settings → Integrations.'}
+        </p>
+      ) : (
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 font-medium">When</th>
+                <th className="px-3 py-2 font-medium">Title</th>
+                <th className="px-3 py-2 font-medium">Linked to</th>
+                <th className="px-3 py-2 font-medium">Artifacts</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((m) => (
+                <Row key={m.id} meeting={m} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({ meeting }: { meeting: MeetingDto }) {
+  const start = new Date(meeting.scheduledStart);
+  return (
+    <tr className="border-t">
+      <td className="px-3 py-2 align-top">
+        <div className="font-mono text-xs">
+          {start.toLocaleDateString()} {start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+        </div>
+      </td>
+      <td className="px-3 py-2 align-top">
+        <div className="font-medium">{meeting.title}</div>
+        {meeting.summaryExcerpt ? (
+          <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+            {meeting.summaryExcerpt}
+          </div>
+        ) : null}
+      </td>
+      <td className="px-3 py-2 align-top">
+        {meeting.primaryDeal ? (
+          <Link
+            to={`/deals/${meeting.primaryDeal.id}`}
+            className="text-primary hover:underline"
+          >
+            {meeting.primaryDeal.title}
+          </Link>
+        ) : meeting.primaryContact ? (
+          <Link
+            to={`/contacts/${meeting.primaryContact.id}`}
+            className="text-primary hover:underline"
+          >
+            {meeting.primaryContact.firstName} {meeting.primaryContact.lastName}
+          </Link>
+        ) : meeting.primaryCompany ? (
+          <Link
+            to={`/companies/${meeting.primaryCompany.id}`}
+            className="text-primary hover:underline"
+          >
+            {meeting.primaryCompany.name}
+          </Link>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </td>
+      <td className="px-3 py-2 align-top">
+        <div className="flex flex-wrap gap-1">
+          <ArtifactPill href={meeting.recordingUrl} icon={<Video className="h-3 w-3" />} label="Rec" />
+          <ArtifactPill href={meeting.summaryDocUrl} icon={<Sparkles className="h-3 w-3" />} label="Sum" />
+          <ArtifactPill href={meeting.transcriptDocUrl} icon={<FileText className="h-3 w-3" />} label="Tr" />
+        </div>
+      </td>
+      <td className="px-3 py-2 align-top">
+        <StatusBadge status={meeting.linkStatus} />
+      </td>
+    </tr>
+  );
+}
+
+function ArtifactPill({
+  href,
+  icon,
+  label,
+}: {
+  href: string | null;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  if (!href) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded border border-dashed border-border/60 px-1.5 py-0.5 text-[10px] text-muted-foreground/70">
+        {icon}
+        {label}
+      </span>
+    );
+  }
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      className="inline-flex items-center gap-1 rounded border border-border/70 bg-background px-1.5 py-0.5 text-[10px] hover:border-foreground/40 hover:bg-muted"
+    >
+      {icon}
+      {label}
+    </a>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === 'confirmed') {
+    return (
+      <Badge variant="outline" className="border-emerald-500/40 text-emerald-600 dark:text-emerald-400">
+        Linked
+      </Badge>
+    );
+  }
+  if (status === 'suggested') {
+    return (
+      <Badge variant="outline" className="border-amber-500/40 text-amber-600 dark:text-amber-400">
+        Needs review
+      </Badge>
+    );
+  }
+  if (status === 'rejected') {
+    return (
+      <Badge variant="outline" className="text-muted-foreground">
+        Rejected
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="text-muted-foreground">
+      Unlinked
+    </Badge>
+  );
+}
+
+function MeetingsCalendar() {
+  const navigate = useNavigate();
+  const { data } = useQuery({
+    queryKey: ['meetings', 'calendar'],
+    queryFn: () =>
+      api.get<{ meetings: MeetingDto[] }>('/meetings?limit=200'),
+    staleTime: 30_000,
+  });
+
+  const events = (data?.meetings ?? []).map((m) => ({
+    id: `meeting-${m.id}`,
+    title: m.title,
+    start: m.scheduledStart,
+    end: m.scheduledEnd,
+    extendedProps: {
+      hasRecording: Boolean(m.recordingUrl),
+      hasSummary: Boolean(m.summaryDocUrl),
+      linkStatus: m.linkStatus,
+      meetingId: m.id,
+      // Pre-resolve the click target. A meeting with a deal goes to the
+      // deal page; otherwise contact, otherwise company. A meeting with
+      // no link gets nowhere — clicking is a no-op rather than a 404.
+      navigateTo:
+        m.primaryDeal?.id != null
+          ? `/deals/${m.primaryDeal.id}`
+          : m.primaryContact?.id != null
+          ? `/contacts/${m.primaryContact.id}`
+          : m.primaryCompany?.id != null
+          ? `/companies/${m.primaryCompany.id}`
+          : null,
+    },
+  }));
+
+  return (
+    <div className="surface-elevated h-[calc(100dvh-18rem)] min-h-[480px] overflow-hidden rounded-xl p-2 sm:p-3 md:p-5">
+      <FullCalendar
+        plugins={[dayGridPlugin, interactionPlugin]}
+        initialView="dayGridMonth"
+        headerToolbar={{
+          left: 'prev,next today',
+          center: 'title',
+          right: 'dayGridMonth,dayGridWeek',
+        }}
+        buttonText={{ today: 'Today', month: 'Month', week: 'Week' }}
+        events={events}
+        height="100%"
+        expandRows
+        dayMaxEvents
+        eventClick={(info) => {
+          info.jsEvent.preventDefault();
+          const target = info.event.extendedProps.navigateTo as string | null;
+          if (target) navigate(target);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/pages/settings/IntegrationsCard.tsx
+++ b/apps/web/src/pages/settings/IntegrationsCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSearchParams } from 'react-router-dom';
-import { Link2, Link2Off, RefreshCw, AlertTriangle, Mail } from 'lucide-react';
+import { Link2, Link2Off, RefreshCw, AlertTriangle, Mail, Video } from 'lucide-react';
 import { toast } from 'sonner';
 import { api, ApiError } from '@/lib/api';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -26,6 +26,11 @@ type GoogleStatus = {
     lastPulledAt: string | null;
     lastPushedAt: string | null;
     initialImportedCount: number;
+  } | null;
+  calendar: {
+    enabled: boolean;
+    lastEventsSyncedAt: string | null;
+    lastArtifactsSyncedAt: string | null;
   } | null;
 };
 
@@ -85,13 +90,34 @@ export function IntegrationsCard() {
   }, [searchParams, setSearchParams]);
 
   const start = useMutation({
-    mutationFn: () => api.get<{ url: string }>('/integrations/google/start?intent=contacts'),
+    mutationFn: (intent: 'contacts' | 'calendar') =>
+      api.get<{ url: string }>(`/integrations/google/start?intent=${intent}`),
     onSuccess: ({ url }) => {
       // Full-page nav to Google's consent screen — we'll come back via
       // /api/integrations/google/callback which redirects to this page.
       window.location.href = url;
     },
     onError: (e) => toast.error(formatApiError(e, 'Could not start Google connection')),
+  });
+
+  const resyncCalendar = useMutation({
+    mutationFn: () =>
+      api.post<{ enqueued: 'incremental' }>('/integrations/google/calendar/resync'),
+    onSuccess: () => {
+      toast.success('Calendar resync enqueued');
+      void qc.invalidateQueries({ queryKey: ['integrations', 'google', 'status'] });
+    },
+    onError: (e) => toast.error(formatApiError(e, 'Could not enqueue calendar resync')),
+  });
+
+  const backfillCalendar = useMutation({
+    mutationFn: () =>
+      api.post<{ enqueued: 'backfill' }>('/integrations/google/calendar/backfill'),
+    onSuccess: () => {
+      toast.success('Backfill enqueued — pulling the last 90 days');
+      void qc.invalidateQueries({ queryKey: ['integrations', 'google', 'status'] });
+    },
+    onError: (e) => toast.error(formatApiError(e, 'Could not enqueue backfill')),
   });
 
   const disconnect = useMutation({
@@ -177,10 +203,16 @@ export function IntegrationsCard() {
               resyncing={resync.isPending}
               onSetOutbound={(v) => setOutbound.mutate(v)}
               outboundPending={setOutbound.isPending}
+              onConnectCalendar={() => start.mutate('calendar')}
+              startingCalendar={start.isPending}
+              onResyncCalendar={() => resyncCalendar.mutate()}
+              resyncingCalendar={resyncCalendar.isPending}
+              onBackfillCalendar={() => backfillCalendar.mutate()}
+              backfillingCalendar={backfillCalendar.isPending}
             />
           ) : (
             <DisconnectedState
-              onConnect={() => start.mutate()}
+              onConnect={() => start.mutate('contacts')}
               starting={start.isPending}
               configured={data?.configured ?? false}
               disabledReason={data?.account?.disabledReason ?? null}
@@ -225,6 +257,12 @@ function ConnectedState(props: {
   resyncing: boolean;
   onSetOutbound: (next: boolean) => void;
   outboundPending: boolean;
+  onConnectCalendar: () => void;
+  startingCalendar: boolean;
+  onResyncCalendar: () => void;
+  resyncingCalendar: boolean;
+  onBackfillCalendar: () => void;
+  backfillingCalendar: boolean;
 }) {
   const { status } = props;
   const account = status.account!;
@@ -286,7 +324,7 @@ function ConnectedState(props: {
       <div className="flex flex-wrap gap-2">
         <Button variant="outline" onClick={props.onResync} disabled={props.resyncing}>
           <RefreshCw className={`mr-2 h-4 w-4 ${props.resyncing ? 'animate-spin' : ''}`} />
-          {props.resyncing ? 'Syncing…' : 'Resync now'}
+          {props.resyncing ? 'Syncing…' : 'Resync contacts'}
         </Button>
         <Button
           variant="outline"
@@ -296,6 +334,68 @@ function ConnectedState(props: {
           <Link2Off className="mr-2 h-4 w-4" />
           {props.disconnecting ? 'Disconnecting…' : 'Disconnect'}
         </Button>
+      </div>
+
+      <div className="rounded-md border border-border/60 bg-muted/30 px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <Label className="flex items-center gap-2 text-sm font-medium">
+              <Video className="h-4 w-4" />
+              Calendar &amp; Meet
+            </Label>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Pull customer Calendar events into deals and attach Meet
+              recordings, Gemini summaries, and transcripts. Polling every
+              5 minutes once connected. Requires re-consent because the
+              Calendar / Meet / Drive scopes weren&apos;t granted at first
+              sign-in.
+            </p>
+            {status.calendar ? (
+              <p className="mt-2 text-xs text-muted-foreground">
+                Last synced: {formatRelative(status.calendar.lastEventsSyncedAt)} ·
+                Last artifacts run: {formatRelative(status.calendar.lastArtifactsSyncedAt)}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex shrink-0 flex-col gap-2">
+            {status.calendar ? (
+              <>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={props.onResyncCalendar}
+                  disabled={props.resyncingCalendar}
+                >
+                  <RefreshCw
+                    className={`mr-2 h-4 w-4 ${props.resyncingCalendar ? 'animate-spin' : ''}`}
+                  />
+                  {props.resyncingCalendar ? 'Syncing…' : 'Resync calendar'}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={props.onBackfillCalendar}
+                  disabled={props.backfillingCalendar}
+                  title="Re-pull the last 90 days. Useful if you connected before older meetings were available."
+                >
+                  <RefreshCw
+                    className={`mr-2 h-4 w-4 ${props.backfillingCalendar ? 'animate-spin' : ''}`}
+                  />
+                  {props.backfillingCalendar ? 'Backfilling…' : 'Backfill 90d'}
+                </Button>
+              </>
+            ) : (
+              <Button
+                size="sm"
+                onClick={props.onConnectCalendar}
+                disabled={props.startingCalendar}
+              >
+                <Link2 className="mr-2 h-4 w-4" />
+                {props.startingCalendar ? 'Redirecting…' : 'Enable Calendar'}
+              </Button>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -99,12 +99,16 @@ export interface TaskDto {
   title: string;
   description: string | null;
   dueDate: string | null;
-  status: 'pending' | 'completed';
+  status: 'pending' | 'completed' | 'pending_review' | 'dismissed';
   completedAt: string | null;
   dealId: number | null;
   deal: { id: number; title: string } | null;
   assignedTo: number | null;
   assignee: { id: number; name: string; avatarColor: string } | null;
+  sourceMeetingId?: number | null;
+  sourceActionItemText?: string | null;
+  autoExtracted?: boolean;
+  customerCommitment?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -113,9 +117,51 @@ export interface NoteDto {
   id: number;
   content: string;
   dealId: number;
+  meetingId?: number | null;
+  source?: 'manual' | 'meeting_summary' | 'ai_extracted';
   createdBy: number;
   author: { id: number; name: string; avatarColor: string } | null;
   createdAt: string;
+}
+
+export interface MeetingAttendeeDto {
+  id: number;
+  email: string;
+  name: string | null;
+  responseStatus: string | null;
+  isOrganizer: boolean;
+  contact: { id: number; firstName: string; lastName: string } | null;
+  user: { id: number; name: string } | null;
+}
+
+export interface MeetingDto {
+  id: number;
+  calendarEventId: string;
+  title: string;
+  description: string | null;
+  scheduledStart: string;
+  scheduledEnd: string;
+  status: string;
+  organizerEmail: string;
+  organizer: { id: number; name: string; avatarColor: string } | null;
+  primaryContactId: number | null;
+  primaryContact: { id: number; firstName: string; lastName: string } | null;
+  primaryDealId: number | null;
+  primaryDeal: { id: number; title: string } | null;
+  primaryCompanyId: number | null;
+  primaryCompany: { id: number; name: string } | null;
+  linkStatus: 'unlinked' | 'suggested' | 'confirmed' | 'rejected' | string;
+  linkConfidence: number | null;
+  linkMethod: string | null;
+  recordingUrl: string | null;
+  summaryDocUrl: string | null;
+  summaryExcerpt: string | null;
+  transcriptDocUrl: string | null;
+  artifactsProcessedAt: string | null;
+  artifactsPartial: boolean;
+  attendees: MeetingAttendeeDto[];
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface AttachmentDto {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -2,6 +2,8 @@ import { Worker } from 'bullmq';
 import {
   QUEUE_ENRICH_COMPANY,
   QUEUE_GENERATE,
+  QUEUE_GOOGLE_CALENDAR_ARTIFACTS,
+  QUEUE_GOOGLE_CALENDAR_PULL,
   QUEUE_GOOGLE_CONTACTS_PULL,
   QUEUE_GOOGLE_CONTACTS_PUSH,
   QUEUE_S3_CLEANUP,
@@ -15,6 +17,8 @@ import { redisConnection, s3CleanupProducer } from './queue.js';
 import { prisma } from './db.js';
 import { processEnrichCompany } from './jobs/enrichCompany.js';
 import { processGenerate } from './jobs/generate.js';
+import { processGoogleCalendarArtifacts } from './jobs/googleCalendarArtifacts.js';
+import { processGoogleCalendarPull } from './jobs/googleCalendarPull.js';
 import { processGoogleContactsPull } from './jobs/googleContactsPull.js';
 import { processGoogleContactsPush } from './jobs/googleContactsPush.js';
 import { processS3Cleanup } from './jobs/s3Cleanup.js';
@@ -146,6 +150,52 @@ googleContactsPushWorker.on('error', (err) => {
   logger.error({ err }, 'google contacts push worker error');
 });
 
+// Calendar pull / artifacts. Same per-account-serial concurrency story
+// as contacts: jobId pinning on the producer side keeps a single account
+// from queueing parallel pulls; concurrency 2 globally lets two accounts
+// run in parallel but caps fan-out under burst.
+const googleCalendarPullWorker = new Worker(
+  QUEUE_GOOGLE_CALENDAR_PULL,
+  processGoogleCalendarPull,
+  { connection: redisConnection, concurrency: 2 },
+);
+googleCalendarPullWorker.on('completed', (job, result) => {
+  logger.debug(
+    { jobId: job.id, upserted: result?.upserted, matched: result?.matched },
+    'calendar pull completed',
+  );
+});
+googleCalendarPullWorker.on('failed', (job, err) => {
+  logger.warn(
+    { jobId: job?.id, googleAccountId: job?.data?.googleAccountId, err: err.message },
+    'calendar pull failed',
+  );
+});
+googleCalendarPullWorker.on('error', (err) => {
+  logger.error({ err }, 'calendar pull worker error');
+});
+
+const googleCalendarArtifactsWorker = new Worker(
+  QUEUE_GOOGLE_CALENDAR_ARTIFACTS,
+  processGoogleCalendarArtifacts,
+  { connection: redisConnection, concurrency: 2 },
+);
+googleCalendarArtifactsWorker.on('completed', (job, result) => {
+  logger.debug(
+    { jobId: job.id, attached: result?.attached, partial: result?.partial },
+    'calendar artifacts completed',
+  );
+});
+googleCalendarArtifactsWorker.on('failed', (job, err) => {
+  logger.warn(
+    { jobId: job?.id, googleAccountId: job?.data?.googleAccountId, err: err.message },
+    'calendar artifacts failed',
+  );
+});
+googleCalendarArtifactsWorker.on('error', (err) => {
+  logger.error({ err }, 'calendar artifacts worker error');
+});
+
 s3ReconcileWorker.on('completed', (job, result) => {
   logger.info(
     { jobId: job.id, scanned: result?.scanned, orphaned: result?.orphaned },
@@ -241,6 +291,8 @@ const shutdown = async (signal: string) => {
       scheduledBackupWorker.close(),
       googleContactsPullWorker.close(),
       googleContactsPushWorker.close(),
+      googleCalendarPullWorker.close(),
+      googleCalendarArtifactsWorker.close(),
       enrichCompanyWorker.close(),
       s3CleanupProducer.close(),
     ]);

--- a/apps/worker/src/integrations/google/calendarClient.ts
+++ b/apps/worker/src/integrations/google/calendarClient.ts
@@ -1,0 +1,91 @@
+import { google, type calendar_v3, type drive_v3, type docs_v1 } from 'googleapis';
+import { OAuth2Client, type Credentials } from 'google-auth-library';
+import type { GoogleAccount } from '@prisma/client';
+import { prisma } from '../../db.js';
+import { env } from '../../env.js';
+import { encryptSecret, decryptSecret } from '../../lib/crypto.js';
+import { logger } from '../../logger.js';
+import { GoogleAccountDisabledError } from './peopleClient.js';
+
+// Client factory for the Calendar / Meet / Drive / Docs APIs we need for
+// the meeting-ingest pipeline. Mirrors peopleClient.ts in shape — same
+// `tokens` event handling for refresh-token rotation, same disabled-flag
+// gating — but bundles four API clients off the same OAuth2Client so a
+// single job run can cross APIs without re-authing.
+//
+// Why four clients? See spec-artifact-attach.md: Meet's REST API exposes
+// recordings + transcripts but *not* the Gemini summary Doc, which only
+// surfaces in Drive. We need Calendar to discover events, Meet to fetch
+// conferenceRecords, Drive to find the summary by title, and Docs to read
+// the summary body for excerpt + action-item extraction.
+
+export type CalendarClient = calendar_v3.Calendar;
+export type MeetClient = ReturnType<typeof google.meet>;
+export type DriveClient = drive_v3.Drive;
+export type DocsClient = docs_v1.Docs;
+
+export type CalendarHandle = {
+  oauth: OAuth2Client;
+  calendar: CalendarClient;
+  meet: MeetClient;
+  drive: DriveClient;
+  docs: DocsClient;
+  account: GoogleAccount;
+};
+
+export async function buildCalendarHandle(account: GoogleAccount): Promise<CalendarHandle> {
+  if (account.disabledAt) {
+    throw new GoogleAccountDisabledError(account.disabledReason ?? 'unknown', account.id);
+  }
+  const refreshToken = decryptSecret(
+    account.encryptedRefreshToken,
+    env.GOOGLE_TOKEN_ENCRYPTION_KEY,
+  );
+  const oauth = new OAuth2Client({
+    clientId: env.GOOGLE_OAUTH_CLIENT_ID,
+    clientSecret: env.GOOGLE_OAUTH_CLIENT_SECRET,
+  });
+  oauth.setCredentials({ refresh_token: refreshToken });
+
+  // Same rotation-listener pattern as peopleClient — google-auth-library
+  // emits `tokens` when it rotates, and we re-encrypt + persist so a worker
+  // restart immediately afterwards doesn't lose the new token.
+  oauth.on('tokens', (tokens: Credentials) => {
+    void (async () => {
+      try {
+        const updates: Record<string, unknown> = { lastRefreshedAt: new Date() };
+        if (tokens.refresh_token) {
+          updates.encryptedRefreshToken = encryptSecret(
+            tokens.refresh_token,
+            env.GOOGLE_TOKEN_ENCRYPTION_KEY,
+          );
+        }
+        if (tokens.access_token) {
+          updates.accessToken = tokens.access_token;
+          updates.accessTokenExpiresAt = tokens.expiry_date
+            ? new Date(tokens.expiry_date)
+            : new Date(Date.now() + 3_500_000);
+        }
+        await prisma.googleAccount.update({
+          where: { id: account.id },
+          data: updates,
+        });
+      } catch (err) {
+        logger.warn({ err, accountId: account.id }, 'failed to persist rotated google tokens');
+      }
+    })();
+  });
+
+  return {
+    oauth,
+    calendar: google.calendar({ version: 'v3', auth: oauth }),
+    // The Meet REST API's `meet` client lives at v2 in googleapis. We use
+    // it for conferenceRecords.recordings.list / transcripts.list — the
+    // first-party path for recording / transcript metadata.
+    meet: google.meet({ version: 'v2', auth: oauth }),
+    drive: google.drive({ version: 'v3', auth: oauth }),
+    docs: google.docs({ version: 'v1', auth: oauth }),
+    account,
+  };
+}
+

--- a/apps/worker/src/integrations/google/meetingMatcher.test.ts
+++ b/apps/worker/src/integrations/google/meetingMatcher.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decideMatch,
+  domainOf,
+  type DealCandidate,
+  type MatcherInputs,
+} from './meetingMatcher.js';
+
+// Pure-function tests — the matcher is deliberately Prisma-free so the
+// fixtures here line up 1:1 with what the worker passes in.
+
+function baseInput(over: Partial<MatcherInputs> = {}): MatcherInputs {
+  return {
+    externalAttendeeEmails: [],
+    eventTitle: '',
+    contactsByAttendee: [],
+    openDealsByContact: new Map(),
+    companiesByDomain: [],
+    ...over,
+  };
+}
+
+describe('decideMatch', () => {
+  it('auto-confirms a single-contact / single-deal match at 1.00', () => {
+    const deal: DealCandidate = {
+      id: 100,
+      title: 'Acme Q3 Renewal',
+      primaryContactId: 1,
+      companyId: 7,
+    };
+    const decision = decideMatch(
+      baseInput({
+        externalAttendeeEmails: ['jane@acme.com'],
+        eventTitle: 'Acme renewal call',
+        contactsByAttendee: [{ id: 1, email: 'jane@acme.com', companyId: 7 }],
+        openDealsByContact: new Map([[1, [deal]]]),
+      }),
+    );
+    expect(decision.outcome).toBe('auto_confirmed');
+    expect(decision.confidence).toBe(1);
+    expect(decision.primaryDealId).toBe(100);
+    expect(decision.method).toBe('email_match');
+  });
+
+  it('drops to title disambiguation at 0.85 when multiple deals match', () => {
+    const renewal: DealCandidate = {
+      id: 100,
+      title: 'Acme Q3 Renewal',
+      primaryContactId: 1,
+      companyId: 7,
+    };
+    const expansion: DealCandidate = {
+      id: 200,
+      title: 'Acme Expansion',
+      primaryContactId: 1,
+      companyId: 7,
+    };
+    const decision = decideMatch(
+      baseInput({
+        externalAttendeeEmails: ['jane@acme.com'],
+        eventTitle: 'Acme renewal call',
+        contactsByAttendee: [{ id: 1, email: 'jane@acme.com', companyId: 7 }],
+        openDealsByContact: new Map([[1, [renewal, expansion]]]),
+      }),
+    );
+    expect(decision.outcome).toBe('suggested');
+    expect(decision.confidence).toBeCloseTo(0.85, 2);
+    expect(decision.primaryDealId).toBe(100);
+    expect(decision.method).toBe('title_match');
+  });
+
+  it('leaves the deal pending when title is too generic to disambiguate', () => {
+    const renewal: DealCandidate = {
+      id: 100,
+      title: 'Acme Q3 Renewal',
+      primaryContactId: 1,
+      companyId: 7,
+    };
+    const expansion: DealCandidate = {
+      id: 200,
+      title: 'Acme Expansion',
+      primaryContactId: 1,
+      companyId: 7,
+    };
+    const decision = decideMatch(
+      baseInput({
+        externalAttendeeEmails: ['jane@acme.com'],
+        eventTitle: 'Acme call',
+        contactsByAttendee: [{ id: 1, email: 'jane@acme.com', companyId: 7 }],
+        openDealsByContact: new Map([[1, [renewal, expansion]]]),
+      }),
+    );
+    expect(decision.outcome).toBe('suggested');
+    expect(decision.confidence).toBeCloseTo(0.7, 2);
+    expect(decision.primaryDealId).toBeNull();
+    expect(decision.primaryContactId).toBe(1);
+  });
+
+  it('falls back to domain match when no contact matches', () => {
+    const decision = decideMatch(
+      baseInput({
+        externalAttendeeEmails: ['someone@acme.com'],
+        eventTitle: 'Acme intro',
+        companiesByDomain: [{ id: 7, domains: ['acme.com'] }],
+      }),
+    );
+    expect(decision.outcome).toBe('suggested');
+    expect(decision.confidence).toBeCloseTo(0.5, 2);
+    expect(decision.method).toBe('domain_match');
+    expect(decision.primaryCompanyId).toBe(7);
+  });
+
+  it('emits unlinked when nothing matches', () => {
+    const decision = decideMatch(
+      baseInput({ externalAttendeeEmails: ['stranger@example.org'] }),
+    );
+    expect(decision.outcome).toBe('unlinked');
+    expect(decision.method).toBeNull();
+  });
+
+  it('does not auto-confirm when contact matched but no open deals', () => {
+    const decision = decideMatch(
+      baseInput({
+        externalAttendeeEmails: ['jane@acme.com'],
+        eventTitle: 'Catch-up',
+        contactsByAttendee: [{ id: 1, email: 'jane@acme.com', companyId: 7 }],
+        openDealsByContact: new Map(),
+      }),
+    );
+    expect(decision.outcome).toBe('suggested');
+    expect(decision.confidence).toBeCloseTo(0.7, 2);
+    expect(decision.primaryDealId).toBeNull();
+    expect(decision.primaryContactId).toBe(1);
+  });
+
+  it('refuses to disambiguate to multiple companies', () => {
+    const decision = decideMatch(
+      baseInput({
+        externalAttendeeEmails: ['a@acme.com', 'b@example.com'],
+        eventTitle: 'Joint review',
+        companiesByDomain: [
+          { id: 7, domains: ['acme.com'] },
+          { id: 8, domains: ['example.com'] },
+        ],
+      }),
+    );
+    // Multi-company auto-link is intentionally out of scope.
+    expect(decision.outcome).toBe('unlinked');
+  });
+});
+
+describe('domainOf', () => {
+  it('lowercases and trims', () => {
+    expect(domainOf('  Jane@Acme.COM ')).toBe('acme.com');
+  });
+  it('handles `Display Name <email@x.com>` wrapping', () => {
+    expect(domainOf('Jane Doe <jane@acme.com>')).toBe('acme.com');
+  });
+  it('returns null for malformed addresses', () => {
+    expect(domainOf('jane@')).toBeNull();
+    expect(domainOf('jane')).toBeNull();
+  });
+});

--- a/apps/worker/src/integrations/google/meetingMatcher.ts
+++ b/apps/worker/src/integrations/google/meetingMatcher.ts
@@ -1,0 +1,271 @@
+// Auto-link matcher — given a freshly-ingested Calendar event's attendee
+// emails and the event title, decide which (Contact, Deal, Company) the
+// resulting Meeting should anchor to. Pure data → decision; the worker
+// hands in already-loaded Contact/Deal/Company candidates so this module
+// stays Prisma-free and trivial to unit-test.
+//
+// The confidence ladder mirrors spec-auto-link-meeting.md:
+//
+//   1.00  single Contact match + single open Deal
+//   0.85  single Contact match + Deal disambiguated by title
+//   0.70  single Contact match + multiple open Deals (Contact only)
+//   0.50  domain match only (no Contact, Company linked)
+//   <0.50 do not auto-suggest
+//
+// The matcher's contract:
+//   - Returns one decision plus a candidates trail for audit logging.
+//   - Never invents a primary deal when ambiguity remains — the rep
+//     confirms ambiguous cases.
+//   - Knows nothing about persistence; that's the caller's job. This
+//     means the same matcher can be reused unchanged when a future Push
+//     ingest path needs to re-evaluate a Meeting after attendee edits.
+
+export interface ContactCandidate {
+  id: number;
+  email: string | null;
+  companyId: number | null;
+}
+
+export interface DealCandidate {
+  id: number;
+  title: string;
+  // closed_won / closed_lost are EXCLUDED upstream — the matcher only
+  // ever sees deals worth attaching to.
+  primaryContactId: number | null;
+  companyId: number | null;
+}
+
+export interface CompanyCandidate {
+  id: number;
+  domains: string[]; // normalized lowercase
+}
+
+export interface MatcherInputs {
+  // Lowercased, trimmed attendee emails. Internal-domain attendees are
+  // expected to be filtered out by the caller (we don't know what counts
+  // as internal at this layer — it's per-org config).
+  externalAttendeeEmails: string[];
+  eventTitle: string;
+  // Loaded by the caller from Postgres: any Contacts whose email matches
+  // an attendee. Multiple Contacts is unusual but possible (shared inbox,
+  // duplicates from imports).
+  contactsByAttendee: ContactCandidate[];
+  // Open deals associated with the matched contacts (or with their
+  // companies). Caller filters to non-closed.
+  openDealsByContact: Map<number, DealCandidate[]>;
+  // For domain-match fallback: companies whose `domains[]` contains any
+  // attendee email's domain.
+  companiesByDomain: CompanyCandidate[];
+}
+
+export interface AuditCandidate {
+  kind: 'contact' | 'deal' | 'company';
+  id: number;
+  score: number;
+  reason: string;
+}
+
+export interface MatchDecision {
+  primaryContactId: number | null;
+  primaryDealId: number | null;
+  primaryCompanyId: number | null;
+  // 0.00 — 1.00. We persist as Decimal(3,2); store the rounded value.
+  confidence: number;
+  // 'email_match' | 'domain_match' | 'title_match' | null when nothing
+  // could be linked.
+  method: 'email_match' | 'domain_match' | 'title_match' | null;
+  // Final state — caller maps to Meeting.linkStatus.
+  // 'confirmed' is reserved for the confidence === 1.00 path *iff* the
+  // org has auto-confirm enabled. The matcher emits 'auto_confirmed' so
+  // the caller can decide whether to honor it; downgrades to 'suggested'
+  // when org policy disallows.
+  outcome: 'auto_confirmed' | 'suggested' | 'unlinked';
+  candidates: AuditCandidate[];
+}
+
+const SCORE_FULL = 1.0;
+const SCORE_TITLE_DISAMBIGUATED = 0.85;
+const SCORE_CONTACT_ONLY = 0.7;
+const SCORE_DOMAIN_ONLY = 0.5;
+
+export function decideMatch(input: MatcherInputs): MatchDecision {
+  const trail: AuditCandidate[] = [];
+
+  // Email match — collect unique contacts hit by the attendee list. If
+  // multiple Contacts hit (same email on two records — rare but happens),
+  // fall through to "no clean contact match" and let the matcher try
+  // domain match instead.
+  const uniqueContacts = uniqueById(input.contactsByAttendee);
+  for (const c of uniqueContacts) {
+    trail.push({
+      kind: 'contact',
+      id: c.id,
+      score: SCORE_CONTACT_ONLY,
+      reason: 'attendee email matched contact',
+    });
+  }
+
+  if (uniqueContacts.length === 1) {
+    const contact = uniqueContacts[0]!;
+    const deals = input.openDealsByContact.get(contact.id) ?? [];
+    if (deals.length === 1) {
+      const deal = deals[0]!;
+      trail.push({
+        kind: 'deal',
+        id: deal.id,
+        score: SCORE_FULL,
+        reason: 'sole open deal on the matched contact',
+      });
+      return {
+        primaryContactId: contact.id,
+        primaryDealId: deal.id,
+        primaryCompanyId: contact.companyId,
+        confidence: SCORE_FULL,
+        method: 'email_match',
+        outcome: 'auto_confirmed',
+        candidates: trail,
+      };
+    }
+    if (deals.length > 1) {
+      // Title disambiguation. We score each deal by how many of its
+      // *distinctive* tokens appear in the event title, then pick the
+      // deal that strictly out-scores its peers. "Distinctive" excludes
+      // tokens that are shared by every candidate deal — those are
+      // typically the company / account name (e.g. "Acme" in both
+      // "Acme Q3 Renewal" and "Acme Expansion"), which carry no
+      // signal for picking *between* the two.
+      const title = input.eventTitle.toLowerCase();
+      const tokenSets = deals.map((d) => tokensOf(d.title));
+      const sharedByAll = new Set<string>();
+      if (tokenSets[0]) {
+        for (const t of tokenSets[0]) {
+          if (tokenSets.every((set) => set.has(t))) sharedByAll.add(t);
+        }
+      }
+      const scores = deals.map((d, i) => {
+        const distinctive = Array.from(tokenSets[i]!).filter(
+          (t) => !sharedByAll.has(t) && t.length > 3,
+        );
+        const hits = distinctive.filter((t) => title.includes(t)).length;
+        return { deal: d, score: hits };
+      });
+      for (const { deal, score } of scores) {
+        trail.push({
+          kind: 'deal',
+          id: deal.id,
+          score: score > 0 ? SCORE_TITLE_DISAMBIGUATED : 0,
+          reason:
+            score > 0
+              ? `${score} distinctive token(s) from the deal title appear in the event title`
+              : 'open deal on contact, but no distinctive token match',
+        });
+      }
+      const ranked = [...scores].sort((a, b) => b.score - a.score);
+      const best = ranked[0];
+      const runnerUp = ranked[1];
+      if (best && runnerUp && best.score > 0 && best.score > runnerUp.score) {
+        return {
+          primaryContactId: contact.id,
+          primaryDealId: best.deal.id,
+          primaryCompanyId: contact.companyId,
+          confidence: SCORE_TITLE_DISAMBIGUATED,
+          method: 'title_match',
+          outcome: 'suggested',
+          candidates: trail,
+        };
+      }
+      // Multiple deals, no clean disambiguation — link the contact, leave
+      // deal pending. UI prompts the rep to pick one.
+      return {
+        primaryContactId: contact.id,
+        primaryDealId: null,
+        primaryCompanyId: contact.companyId,
+        confidence: SCORE_CONTACT_ONLY,
+        method: 'email_match',
+        outcome: 'suggested',
+        candidates: trail,
+      };
+    }
+    // Contact matched, no open deals — still attach the contact and
+    // company so the meeting shows up in the right contact's history.
+    return {
+      primaryContactId: contact.id,
+      primaryDealId: null,
+      primaryCompanyId: contact.companyId,
+      confidence: SCORE_CONTACT_ONLY,
+      method: 'email_match',
+      outcome: 'suggested',
+      candidates: trail,
+    };
+  }
+
+  // No clean contact match (zero contacts or multiple). Fall back to
+  // domain match: if all external attendees share a single Company
+  // domain, link the company. Multi-company attendee lists (a meeting
+  // with two customers!) intentionally don't auto-link to either — the
+  // rep handles those manually.
+  if (input.companiesByDomain.length === 1) {
+    const company = input.companiesByDomain[0]!;
+    trail.push({
+      kind: 'company',
+      id: company.id,
+      score: SCORE_DOMAIN_ONLY,
+      reason: 'attendee email domain matched company',
+    });
+    return {
+      primaryContactId: null,
+      primaryDealId: null,
+      primaryCompanyId: company.id,
+      confidence: SCORE_DOMAIN_ONLY,
+      method: 'domain_match',
+      outcome: 'suggested',
+      candidates: trail,
+    };
+  }
+
+  // Nothing matched. Surface the empty trail anyway — the audit row tells
+  // the operator the matcher *did* run and there were no candidates to
+  // pick from.
+  return {
+    primaryContactId: null,
+    primaryDealId: null,
+    primaryCompanyId: null,
+    confidence: 0,
+    method: null,
+    outcome: 'unlinked',
+    candidates: trail,
+  };
+}
+
+function tokensOf(s: string): Set<string> {
+  return new Set(
+    s
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean),
+  );
+}
+
+function uniqueById<T extends { id: number }>(arr: T[]): T[] {
+  const seen = new Set<number>();
+  const out: T[] = [];
+  for (const item of arr) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    out.push(item);
+  }
+  return out;
+}
+
+// Pull the lowercased domain out of an email — used by callers to build
+// the companiesByDomain set. Robust to surrounding whitespace and the
+// `Display Name <email>` wrapping that Calendar can hand back.
+export function domainOf(email: string): string | null {
+  const trimmed = email.trim().toLowerCase();
+  const at = trimmed.lastIndexOf('@');
+  if (at < 0 || at === trimmed.length - 1) return null;
+  // Strip a possible angle-bracket wrapper.
+  let dom = trimmed.slice(at + 1);
+  if (dom.endsWith('>')) dom = dom.slice(0, -1);
+  return dom || null;
+}

--- a/apps/worker/src/integrations/google/summaryParser.test.ts
+++ b/apps/worker/src/integrations/google/summaryParser.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import type { docs_v1 } from 'googleapis';
+import { flattenDocBody, parseSummaryDoc } from './summaryParser.js';
+
+// Fixture-driven tests for the heuristic Gemini-summary parser. We
+// deliberately don't try to model every possible Gemini doc format;
+// instead we cover the patterns the spec calls out and the obvious
+// edge cases we want robust handling for.
+
+const GEMINI_NOTES_DOC = `
+## Summary
+
+Discussed Q3 renewal terms with Jane and the procurement team. Concerns
+on multi-year discount; agreed to send a revised proposal by Friday.
+
+## Action items
+
+- William: Send revised proposal by Friday
+- Jane (Acme): Confirm signing authority for multi-year terms
+- Follow up next week with the security team
+- **Priya** to circulate the SOC 2 report
+
+## Notes
+
+(unstructured stuff that should not pollute the action items)
+`;
+
+describe('parseSummaryDoc', () => {
+  it('pulls the first body paragraph as excerpt', () => {
+    const result = parseSummaryDoc(GEMINI_NOTES_DOC);
+    expect(result.excerpt).toMatch(/^Discussed Q3 renewal terms/);
+    expect(result.excerpt!.length).toBeLessThanOrEqual(280);
+  });
+
+  it('extracts owner-prefixed action items', () => {
+    const result = parseSummaryDoc(GEMINI_NOTES_DOC);
+    expect(result.actionItems).toHaveLength(4);
+    const [first, second, third, fourth] = result.actionItems;
+    expect(first?.ownerName).toBe('William');
+    expect(first?.action).toBe('Send revised proposal by Friday');
+    expect(second?.ownerName).toBe('Jane (Acme)');
+    expect(third?.ownerName).toBeNull();
+    expect(third?.action).toBe('Follow up next week with the security team');
+    expect(fourth?.ownerName).toBe('Priya');
+    expect(fourth?.action).toMatch(/SOC 2/);
+  });
+
+  it('stops the action-items block at the next heading', () => {
+    const doc = `
+## Action items
+- William: do thing
+- Priya: do other thing
+
+## Some other section
+- William: this should NOT be picked up
+`;
+    const r = parseSummaryDoc(doc);
+    expect(r.actionItems).toHaveLength(2);
+    expect(r.actionItems.map((a) => a.action)).not.toContain(
+      'this should NOT be picked up',
+    );
+  });
+
+  it('returns empty action items when the section is missing', () => {
+    const doc = `## Summary\nGreat call.`;
+    const r = parseSummaryDoc(doc);
+    expect(r.actionItems).toHaveLength(0);
+    expect(r.excerpt).toBe('Great call.');
+  });
+
+  it('truncates an overlong excerpt cleanly on a word boundary', () => {
+    const long = 'X '.repeat(400).trim();
+    const r = parseSummaryDoc(long);
+    expect(r.excerpt!.length).toBeLessThanOrEqual(280);
+    expect(r.excerpt!.endsWith('…')).toBe(true);
+  });
+});
+
+describe('flattenDocBody (Gemini tab traversal)', () => {
+  // Helper: build a Schema$Document with the given paragraphs in either
+  // the doc body or a tab. Mirrors the shape Docs API hands back.
+  const para = (text: string, heading = false): docs_v1.Schema$StructuralElement => ({
+    paragraph: {
+      paragraphStyle: heading ? { namedStyleType: 'HEADING_1' } : {},
+      elements: [{ textRun: { content: text } }],
+    },
+  });
+
+  it('reads default-tab body content', () => {
+    const doc: docs_v1.Schema$Document = {
+      body: { content: [para('Hello world')] },
+    };
+    expect(flattenDocBody(doc)).toContain('Hello world');
+  });
+
+  it('reads content from sibling tabs (the Gemini case)', () => {
+    // Real Gemini docs put summary + transcript in *separate tabs* of
+    // the same Doc. Without traversing tabs the parser sees an empty
+    // body and writes no excerpt / extracts no action items.
+    const doc: docs_v1.Schema$Document = {
+      body: { content: [] },
+      tabs: [
+        {
+          documentTab: {
+            body: {
+              content: [
+                para('Summary', true),
+                para('Discussed Q3 renewal terms with Jane.'),
+                para('Action items', true),
+                para('- William: Send revised proposal'),
+              ],
+            },
+          },
+        },
+        {
+          documentTab: {
+            body: {
+              content: [
+                para('Transcript', true),
+                para('Speaker 1: Hello.'),
+              ],
+            },
+          },
+        },
+      ],
+    };
+    const text = flattenDocBody(doc);
+    const parsed = parseSummaryDoc(text);
+    expect(parsed.excerpt).toMatch(/^Discussed Q3 renewal terms/);
+    expect(parsed.actionItems).toHaveLength(1);
+    expect(parsed.actionItems[0]?.ownerName).toBe('William');
+  });
+
+  it('walks nested childTabs', () => {
+    const doc: docs_v1.Schema$Document = {
+      body: { content: [] },
+      tabs: [
+        {
+          documentTab: { body: { content: [para('Outer')] } },
+          childTabs: [
+            { documentTab: { body: { content: [para('Inner')] } } },
+          ],
+        },
+      ],
+    };
+    const text = flattenDocBody(doc);
+    expect(text).toContain('Outer');
+    expect(text).toContain('Inner');
+  });
+});

--- a/apps/worker/src/integrations/google/summaryParser.ts
+++ b/apps/worker/src/integrations/google/summaryParser.ts
@@ -1,0 +1,253 @@
+// Gemini summary doc parser. Extracts:
+//   - The summary excerpt (first body paragraph or "Summary" section,
+//     truncated to 280 characters).
+//   - Action items as `[Owner Name]: [action description]` lines, with
+//     a fallback to plain "- something to do" bullets when Gemini omits
+//     the owner prefix.
+//
+// We deliberately avoid an LLM call here. Heuristic regex on the text
+// gets ~70% of the value at zero per-call cost; the spec calls for ML
+// only after we have a baseline + tuning data. A future v2 can swap in
+// Anthropic without changing the call site — the function takes plain
+// text and returns a structured result.
+//
+// The input is the *plain text projection* of the Doc body — the caller
+// (worker) flattens the docs.documents.get() response into newline-
+// joined text before handing it here. Keeping the parser plain-text-only
+// lets us write fixture-driven tests without round-tripping the full
+// Docs API tree.
+
+const SUMMARY_MAX_CHARS = 280;
+
+export interface ParsedSummary {
+  excerpt: string | null;
+  actionItems: ParsedActionItem[];
+}
+
+export interface ParsedActionItem {
+  // The literal bullet line, retained for traceability and de-dup on
+  // summary regeneration (Gemini sometimes re-emits the doc up to ~30
+  // minutes after the call). The Task row stores this as
+  // `sourceActionItemText`.
+  rawText: string;
+  // The owner name parsed from `[Owner]: [action]` form. Null when the
+  // bullet doesn't carry an explicit owner — falls through to assigning
+  // the meeting organizer once the worker resolves the row.
+  ownerName: string | null;
+  // The action sentence with the owner prefix stripped. This is what
+  // becomes Task.title. Truncated to 255 chars to fit the column.
+  action: string;
+}
+
+export function parseSummaryDoc(plainText: string): ParsedSummary {
+  if (!plainText) return { excerpt: null, actionItems: [] };
+  const lines = plainText.split(/\r?\n/);
+
+  return {
+    excerpt: extractExcerpt(lines),
+    actionItems: extractActionItems(lines),
+  };
+}
+
+function extractExcerpt(lines: string[]): string | null {
+  // Strategy:
+  //   1. If a "Summary" section heading exists, use the first non-empty
+  //      paragraph after it.
+  //   2. Otherwise, use the first non-empty paragraph in the doc.
+  //   3. Skip lines that are obviously headings (start with #, end with
+  //      a colon and have no other punctuation, or are all-caps).
+  const summaryStart = findSectionStart(lines, /^summary\b/i);
+  const startIndex = summaryStart >= 0 ? summaryStart + 1 : 0;
+  for (let i = startIndex; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    if (!line) continue;
+    if (looksLikeHeading(line)) continue;
+    return truncate(line, SUMMARY_MAX_CHARS);
+  }
+  return null;
+}
+
+function extractActionItems(lines: string[]): ParsedActionItem[] {
+  const start = findSectionStart(lines, /^action\s*items?\b/i);
+  if (start < 0) return [];
+
+  const out: ParsedActionItem[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const raw = lines[i]!.trim();
+    if (!raw) continue;
+    // Stop at the next section heading. A line that's a heading but
+    // *not* a bullet ends the Action items block.
+    if (!isBullet(raw) && looksLikeHeading(raw)) break;
+    if (!isBullet(raw)) continue;
+    const stripped = stripBulletMarker(raw);
+    if (!stripped) continue;
+    out.push(parseActionItemLine(stripped, raw));
+  }
+  return out;
+}
+
+function findSectionStart(lines: string[], pattern: RegExp): number {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    if (!line) continue;
+    // Match a heading whose text matches the pattern. Strip leading
+    // markdown # / numbering and trailing colons before testing.
+    const headingText = line
+      .replace(/^#+\s*/, '')
+      .replace(/^\d+[).]\s*/, '')
+      .replace(/[:.]\s*$/, '')
+      .trim();
+    if (pattern.test(headingText) && looksLikeHeading(line)) return i;
+  }
+  return -1;
+}
+
+function looksLikeHeading(line: string): boolean {
+  // Heading heuristics:
+  //   - Markdown # ## ###
+  //   - Trailing colon with no inner punctuation (e.g. "Summary:" or
+  //     "Action items:")
+  //   - All-caps word-only line
+  if (/^#{1,6}\s+/.test(line)) return true;
+  if (/^[A-Z][A-Za-z0-9 \-_/]+:?$/.test(line) && line.length <= 80) {
+    // Filter false positives: the first non-empty line of a body
+    // paragraph also matches this. Insist on either a colon (heading
+    // marker) or all-uppercase (also heading-like).
+    if (/:\s*$/.test(line)) return true;
+    if (line === line.toUpperCase()) return true;
+  }
+  return false;
+}
+
+function isBullet(line: string): boolean {
+  return /^[-*•]\s+/.test(line) || /^\d+[).]\s+/.test(line);
+}
+
+function stripBulletMarker(line: string): string {
+  return line
+    .replace(/^[-*•]\s+/, '')
+    .replace(/^\d+[).]\s+/, '')
+    .trim();
+}
+
+function parseActionItemLine(stripped: string, raw: string): ParsedActionItem {
+  // Owner-prefix forms we accept:
+  //   "Will follow up on pricing — William"
+  //   "William: Send the deck"
+  //   "**William** to send the deck"
+  //   "[William] follow up on pricing"
+  // Kept narrow on purpose — a too-eager regex starts pulling product
+  // names out as owners ("Acme: review the proposal" would attribute
+  // to Acme as a customer commitment).
+
+  // Form A: "Owner: action" — owner may include letters, spaces, the
+  // usual name punctuation, and parenthetical company suffixes
+  // ("Jane (Acme): ..."). The colon is the strong delimiter; we don't
+  // accept a bare hyphen as a separator here because it's too easy for
+  // a hyphen to appear naturally inside an action sentence and pull
+  // the regex in the wrong direction.
+  let m = /^([A-Z][A-Za-z0-9'.\-() ]{1,60}?)\s*[:—]\s+(.+)$/.exec(stripped);
+  if (m) {
+    return {
+      rawText: raw,
+      ownerName: m[1]!.trim(),
+      action: truncate(m[2]!.trim(), 255),
+    };
+  }
+  // Form B: "**Owner** ..."
+  m = /^\*{1,2}([A-Z][A-Za-z0-9'.\-() ]{1,60})\*{1,2}\s+(.+)$/.exec(stripped);
+  if (m) {
+    return {
+      rawText: raw,
+      ownerName: m[1]!.trim(),
+      action: truncate(m[2]!.trim(), 255),
+    };
+  }
+  // Form C: "[Owner] ..."
+  m = /^\[([A-Z][A-Za-z0-9'.\-() ]{1,60})\]\s+(.+)$/.exec(stripped);
+  if (m) {
+    return {
+      rawText: raw,
+      ownerName: m[1]!.trim(),
+      action: truncate(m[2]!.trim(), 255),
+    };
+  }
+  // No owner — treat the whole bullet as the action.
+  return { rawText: raw, ownerName: null, action: truncate(stripped, 255) };
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  // Cut on the closest preceding word boundary so we don't slice mid-token.
+  const slice = text.slice(0, max - 1);
+  const space = slice.lastIndexOf(' ');
+  if (space > max * 0.5) return `${slice.slice(0, space)}…`;
+  return `${slice}…`;
+}
+
+// Flatten the Docs API body into plain text. The Docs API gives back a
+// tree of paragraphs containing structured elements; we only need the
+// human-readable text for the parser, so we walk the tree and collect
+// textRun.content. Headings come through with paragraphStyle.namedStyleType
+// like "HEADING_1" — we prefix them with "## " so the heading detector
+// picks them up.
+//
+// Tabs: Gemini "Notes by Gemini" docs put summary and transcript in
+// **separate tabs** of the same Doc. The Docs API exposes those at
+// `Document.tabs[].documentTab.body.content` (with optional nested
+// `childTabs`). The default-tab `body` may exist alongside tabs or may
+// be empty when all content lives under a tab. We concatenate every
+// tab's content with the doc-level body so the parser's heading
+// detection still finds "Action items" / "Summary" regardless of which
+// tab Gemini wrote them into.
+import type { docs_v1 } from 'googleapis';
+
+export function flattenDocBody(doc: docs_v1.Schema$Document): string {
+  const sections: string[] = [];
+  const docBody = flattenStructuralElements(doc.body?.content ?? []);
+  if (docBody) sections.push(docBody);
+
+  for (const tab of doc.tabs ?? []) {
+    const tabText = flattenTab(tab);
+    if (tabText) sections.push(tabText);
+  }
+
+  return sections.join('\n\n');
+}
+
+function flattenTab(tab: docs_v1.Schema$Tab): string {
+  const parts: string[] = [];
+  const body = tab.documentTab?.body?.content ?? [];
+  const flat = flattenStructuralElements(body);
+  if (flat) parts.push(flat);
+  for (const child of tab.childTabs ?? []) {
+    const childText = flattenTab(child);
+    if (childText) parts.push(childText);
+  }
+  return parts.join('\n\n');
+}
+
+function flattenStructuralElements(
+  content: docs_v1.Schema$StructuralElement[],
+): string {
+  const out: string[] = [];
+  for (const el of content) {
+    if (!el.paragraph) continue;
+    const para = el.paragraph;
+    const styleType = para.paragraphStyle?.namedStyleType ?? '';
+    const text = (para.elements ?? [])
+      .map((pe) => pe.textRun?.content ?? '')
+      .join('')
+      .replace(/\n+$/, '');
+    if (!text.trim()) {
+      out.push('');
+      continue;
+    }
+    if (/^HEADING_/.test(styleType)) {
+      out.push(`## ${text}`);
+    } else {
+      out.push(text);
+    }
+  }
+  return out.join('\n');
+}

--- a/apps/worker/src/jobs/googleCalendarArtifacts.ts
+++ b/apps/worker/src/jobs/googleCalendarArtifacts.ts
@@ -1,0 +1,538 @@
+import { DelayedError, type Job } from 'bullmq';
+import type {
+  GoogleCalendarArtifactsJobData,
+  GoogleCalendarArtifactsJobResult,
+} from '@pipelineflow/shared';
+import { prisma } from '../db.js';
+import { logger } from '../logger.js';
+import { redisConnection } from '../queue.js';
+import { acquireLock } from '../lib/redisLock.js';
+import { buildCalendarHandle } from '../integrations/google/calendarClient.js';
+import {
+  disableAccount,
+  GoogleAccountDisabledError,
+  isInvalidGrant,
+  loadGoogleAccount,
+  retryAfterMs,
+  statusCodeOf,
+} from '../integrations/google/peopleClient.js';
+import {
+  flattenDocBody,
+  parseSummaryDoc,
+  type ParsedActionItem,
+} from '../integrations/google/summaryParser.js';
+
+// Artifact watcher. For each completed Meeting on this account, fetch
+// recordings + transcripts from the Meet API and search Drive for the
+// "Notes by Gemini" summary doc. On a successful summary fetch, parse
+// the body for the excerpt + action items, write the meeting_summary
+// Note, and create pending_review Tasks.
+//
+// Cadence is the artifacts cron (default 10m). Each run scans the
+// backlog of unprocessed meetings; we don't queue per-meeting jobs
+// because a meeting just-now-completed is cheaper to pick up on the
+// next tick than to fan out a job for. Idempotent: re-running with the
+// URLs already populated is a no-op (we early-return on
+// artifactsProcessedAt).
+//
+// 6-hour cap: meetings whose end time is more than 6h in the past with
+// at least one missing artifact get marked partial=true and stop being
+// retried. This bounds the queue work and avoids infinite polling for
+// meetings that just won't have artifacts (call too short, organizer
+// turned off recording, etc.).
+
+const POST_CALL_GRACE_MS = 5 * 60_000;
+// Give up window measured from whichever is later: end-of-meeting OR
+// when we first ingested the row. The latter clause is what makes
+// backfill work — a meeting from three months ago shouldn't be
+// pre-disqualified just because its `scheduledEnd` is older than the
+// give-up window. We still get 6h of retries after the worker first
+// sees it.
+const GIVE_UP_AFTER_MS = 6 * 60 * 60_000;
+// Limit how many meetings each run processes — Drive search + Doc read
+// are non-trivial calls. The next cron tick picks up anything we miss.
+const MAX_MEETINGS_PER_RUN = 25;
+
+export async function processGoogleCalendarArtifacts(
+  job: Job<GoogleCalendarArtifactsJobData, GoogleCalendarArtifactsJobResult>,
+): Promise<GoogleCalendarArtifactsJobResult> {
+  const log = logger.child({ jobId: job.id, jobName: job.name });
+  const { googleAccountId } = job.data;
+
+  const release = await acquireLock(
+    redisConnection,
+    `google-calendar-artifacts:lock:${googleAccountId}`,
+    6 * 60_000,
+  );
+  if (!release) {
+    log.info({ googleAccountId }, 'artifacts: another run holds the lock, skipping');
+    return { considered: 0, attached: 0, partial: 0 };
+  }
+  try {
+    return await runArtifacts(job, log);
+  } finally {
+    await release();
+  }
+}
+
+type ChildLogger = typeof logger;
+
+async function runArtifacts(
+  job: Job<GoogleCalendarArtifactsJobData, GoogleCalendarArtifactsJobResult>,
+  log: ChildLogger,
+): Promise<GoogleCalendarArtifactsJobResult> {
+  const { googleAccountId } = job.data;
+  const account = await loadGoogleAccount(googleAccountId);
+  if (!account || account.disabledAt) {
+    return { considered: 0, attached: 0, partial: 0 };
+  }
+  const sync = await prisma.googleCalendarSync.findUnique({
+    where: { googleAccountId },
+  });
+  if (!sync || !sync.enabled) {
+    return { considered: 0, attached: 0, partial: 0 };
+  }
+
+  let handle;
+  try {
+    handle = await buildCalendarHandle(account);
+  } catch (err) {
+    if (err instanceof GoogleAccountDisabledError) {
+      return { considered: 0, attached: 0, partial: 0 };
+    }
+    throw err;
+  }
+
+  // Pick the backlog: meetings ingested by this account that completed
+  // at least POST_CALL_GRACE_MS ago and don't have artifacts yet. The
+  // give-up cutoff is computed per-row in JS (Prisma's where can't easily
+  // express MAX(scheduledEnd, createdAt) + 6h) — we over-fetch slightly
+  // and filter, which is fine because we cap at MAX_MEETINGS_PER_RUN
+  // before the API calls anyway.
+  const now = new Date();
+  const cutoffEnd = new Date(now.getTime() - POST_CALL_GRACE_MS);
+  const giveUpFromNow = GIVE_UP_AFTER_MS;
+
+  const candidates = await prisma.meeting.findMany({
+    where: {
+      sourceAccountId: googleAccountId,
+      status: { in: ['completed', 'in_progress'] },
+      scheduledEnd: { lt: cutoffEnd },
+      artifactsProcessedAt: null,
+    },
+    orderBy: { scheduledEnd: 'desc' },
+    // Pull a bit more than we'll process — see partition below.
+    take: MAX_MEETINGS_PER_RUN * 4,
+  });
+
+  const partition = (m: { scheduledEnd: Date; createdAt: Date }) => {
+    // Effective deadline: 6h after whichever is later — the meeting
+    // ending or our ingesting it. Backfilled rows therefore get 6h to
+    // process even when the meeting itself happened months ago.
+    const lastSeen = Math.max(m.scheduledEnd.getTime(), m.createdAt.getTime());
+    return now.getTime() - lastSeen > giveUpFromNow ? 'expired' : 'active';
+  };
+
+  const expired = candidates.filter((m) => partition(m) === 'expired');
+  const active = candidates.filter((m) => partition(m) === 'active');
+
+  if (expired.length > 0) {
+    await prisma.meeting.updateMany({
+      where: { id: { in: expired.map((m) => m.id) } },
+      data: { artifactsProcessedAt: now, artifactsPartial: true },
+    });
+  }
+
+  const meetings = active.slice(0, MAX_MEETINGS_PER_RUN);
+
+  let considered = 0;
+  let attached = 0;
+  let partial = 0;
+
+  for (const meeting of meetings) {
+    considered++;
+    try {
+      const result = await processMeetingArtifacts(handle, meeting, log);
+      if (result === 'attached') attached++;
+      if (result === 'partial') partial++;
+    } catch (err) {
+      if (isInvalidGrant(err)) {
+        await disableAccount(googleAccountId, 'invalid_grant');
+        break;
+      }
+      const status = statusCodeOf(err);
+      if (status === 429) {
+        const ts = Date.now() + retryAfterMs(err);
+        await job.moveToDelayed(ts, job.token);
+        throw new DelayedError();
+      }
+      log.warn(
+        { err, meetingId: meeting.id, googleAccountId },
+        'artifact run on a single meeting failed; continuing',
+      );
+    }
+  }
+
+  await prisma.googleCalendarSync.update({
+    where: { googleAccountId },
+    data: { lastArtifactsSyncedAt: now },
+  });
+
+  log.info(
+    { googleAccountId, considered, attached, partial },
+    'artifacts run complete',
+  );
+  return { considered, attached, partial };
+}
+
+type ProcessOutcome = 'attached' | 'partial' | 'unchanged';
+
+async function processMeetingArtifacts(
+  handle: Awaited<ReturnType<typeof buildCalendarHandle>>,
+  meeting: Awaited<ReturnType<typeof prisma.meeting.findFirst>> & object,
+  log: ChildLogger,
+): Promise<ProcessOutcome> {
+  // Fetch recordings + transcripts via the Meet API. conferenceId is the
+  // space id from the Calendar event; the Meet API takes the qualified
+  // form `conferenceRecords/{name}`. Records live for ~30d before being
+  // garbage-collected by Meet.
+  let recordingUrl: string | null = meeting.recordingUrl;
+  let recordingDriveId: string | null = meeting.recordingDriveId;
+  let transcriptDocUrl: string | null = meeting.transcriptDocUrl;
+  let transcriptDocId: string | null = meeting.transcriptDocId;
+  let summaryDocUrl: string | null = meeting.summaryDocUrl;
+  let summaryDocId: string | null = meeting.summaryDocId;
+  let summaryExcerpt: string | null = meeting.summaryExcerpt;
+
+  if (meeting.conferenceId) {
+    // The Meet API surfaces conferenceRecords keyed by `conferenceRecords/{record}`.
+    // The space id from Calendar is *not* the same as the record id —
+    // each call against a recurring space produces a fresh record. We
+    // list all records for the space, then pick the latest one whose
+    // start time matches the meeting window.
+    try {
+      const recordsResp = await handle.meet.conferenceRecords.list({
+        filter: `space.meeting_code=${meeting.conferenceId}`,
+      });
+      const records = recordsResp.data.conferenceRecords ?? [];
+      const matchedRecord = records.find((r) => recordCoversMeeting(r, meeting));
+      if (matchedRecord?.name) {
+        const recordings = await handle.meet.conferenceRecords.recordings.list({
+          parent: matchedRecord.name,
+        });
+        const rec = (recordings.data.recordings ?? [])[0];
+        if (rec?.driveDestination?.file) {
+          recordingDriveId = rec.driveDestination.file;
+          recordingUrl = `https://drive.google.com/file/d/${recordingDriveId}/view`;
+        }
+        const transcripts = await handle.meet.conferenceRecords.transcripts.list({
+          parent: matchedRecord.name,
+        });
+        const tr = (transcripts.data.transcripts ?? [])[0];
+        if (tr?.docsDestination?.document) {
+          transcriptDocId = tr.docsDestination.document;
+          transcriptDocUrl = `https://docs.google.com/document/d/${transcriptDocId}/edit`;
+        }
+      }
+    } catch (err) {
+      // 404s on a record that hasn't been written yet are normal
+      // pre-grace and stay at debug. Anything else (auth, scope, 5xx)
+      // surfaces as a warn so an operator can see it; the next run will
+      // still retry, but the operator can investigate persistent
+      // failures rather than guessing why artifact buttons stay empty.
+      const status = statusCodeOf(err);
+      const level = status === 404 ? 'debug' : 'warn';
+      log[level](
+        { err, meetingId: meeting.id, status },
+        'meet API returned an error while fetching artifacts; continuing',
+      );
+    }
+  }
+
+  // Find the Gemini summary doc by searching Drive. The summary is
+  // *not* exposed through the Meet API so we have to do this — Gemini
+  // names the doc `[Title] - YYYY/MM/DD - Notes by Gemini` (give or
+  // take spacing variation), and drops it in the Meet Recordings
+  // folder. We search across the whole Drive for the title pattern and
+  // narrow on mime type — folder hierarchy assumptions are too fragile.
+  if (!summaryDocId) {
+    const found = await searchGeminiSummary(handle, meeting);
+    if (found) {
+      summaryDocId = found.id;
+      summaryDocUrl = `https://docs.google.com/document/d/${found.id}/edit`;
+    }
+  }
+
+  // Read + parse the summary doc body once we know its id. The parser
+  // does the heavy lifting (excerpt + action items); we just persist.
+  let parsedActions: ParsedActionItem[] = [];
+  if (summaryDocId && !summaryExcerpt) {
+    try {
+      // includeTabsContent=true is required to populate `Document.tabs[]`
+      // — without it, the API only returns the default-tab body, which is
+      // empty for Gemini docs that put summary + transcript in separate
+      // tabs (the common case).
+      const doc = await handle.docs.documents.get({
+        documentId: summaryDocId,
+        includeTabsContent: true,
+      });
+      const text = flattenDocBody(doc.data);
+      const parsed = parseSummaryDoc(text);
+      if (parsed.excerpt) summaryExcerpt = parsed.excerpt;
+      parsedActions = parsed.actionItems;
+    } catch (err) {
+      // 404s on docs that just haven't been generated yet are normal —
+      // those stay at debug. Anything else (auth, scope mismatch, 5xx)
+      // surfaces as a warn so an operator can see it.
+      const status = statusCodeOf(err);
+      const level = status === 404 ? 'debug' : 'warn';
+      log[level](
+        { err, meetingId: meeting.id, summaryDocId, status },
+        'failed to read summary doc body; continuing',
+      );
+    }
+  }
+
+  const allArtifactsPresent = Boolean(
+    recordingUrl && transcriptDocUrl && summaryDocUrl,
+  );
+
+  // Persist the URLs and the excerpt. Even if we got nothing new, mark
+  // artifactsProcessedAt so the watcher doesn't pick this meeting up
+  // again on every tick — it will retry once the sweeper widens its
+  // backlog window again, which is bounded by the give-up cap.
+  const beforeProcessed = meeting.artifactsProcessedAt;
+  await prisma.meeting.update({
+    where: { id: meeting.id },
+    data: {
+      recordingUrl,
+      recordingDriveId,
+      transcriptDocUrl,
+      transcriptDocId,
+      summaryDocUrl,
+      summaryDocId,
+      summaryExcerpt,
+      artifactsProcessedAt: allArtifactsPresent ? new Date() : null,
+      artifactsPartial: !allArtifactsPresent && isPastGiveUp(meeting),
+    },
+  });
+
+  // Note + tasks creation happens once we successfully fetched the
+  // summary. Idempotent: we look up by (meetingId, source) and skip
+  // when one already exists.
+  if (summaryDocId && summaryExcerpt) {
+    await ensureSummaryNote(meeting, summaryExcerpt, summaryDocUrl);
+  }
+  if (parsedActions.length > 0) {
+    await materializeActionItems(meeting, parsedActions);
+  }
+
+  if (allArtifactsPresent) return 'attached';
+  if (isPastGiveUp(meeting)) return 'partial';
+  // Some new URLs may have landed even if not all three are present;
+  // count that as 'attached' once any artifact field flips from null to
+  // populated. Use beforeProcessed proxy: if we wrote anything new, it's
+  // worth telling the operator the run wasn't a no-op.
+  if (
+    !beforeProcessed &&
+    (recordingUrl || transcriptDocUrl || summaryDocUrl)
+  ) {
+    return 'attached';
+  }
+  return 'unchanged';
+}
+
+function isPastGiveUp(meeting: { scheduledEnd: Date; createdAt: Date }): boolean {
+  const lastSeen = Math.max(meeting.scheduledEnd.getTime(), meeting.createdAt.getTime());
+  return Date.now() - lastSeen > GIVE_UP_AFTER_MS;
+}
+
+function recordCoversMeeting(
+  record: import('googleapis').meet_v2.Schema$ConferenceRecord,
+  meeting: { scheduledStart: Date; scheduledEnd: Date },
+): boolean {
+  if (!record.startTime) return false;
+  const start = new Date(record.startTime).getTime();
+  // A 30-minute slack on either side handles late starts and meetings
+  // that ran long.
+  const slack = 30 * 60_000;
+  return (
+    start >= meeting.scheduledStart.getTime() - slack &&
+    start <= meeting.scheduledEnd.getTime() + slack
+  );
+}
+
+async function searchGeminiSummary(
+  handle: Awaited<ReturnType<typeof buildCalendarHandle>>,
+  meeting: { title: string; scheduledStart: Date },
+): Promise<{ id: string; name: string } | null> {
+  // Drive's q syntax: name contains '<title>' AND mimeType=application/vnd.google-apps.document.
+  // Drive's q-language requires *both* backslash and single-quote to be
+  // escaped with a backslash. Order matters: backslash first so we don't
+  // double-escape the backslash we add for the quote. We also require
+  // "Gemini" in the name to filter out an organizer-crafted doc that
+  // happens to share the meeting title. The match is intentionally
+  // loose because Gemini's exact spacing varies — once we've narrowed
+  // to "title + Gemini + doc", the candidate set is small and the
+  // creation-time check below picks the right one.
+  const safeTitle = meeting.title.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  const q = `name contains '${safeTitle}' and name contains 'Gemini' and mimeType = 'application/vnd.google-apps.document'`;
+  const list = await handle.drive.files.list({
+    q,
+    fields: 'files(id,name,createdTime)',
+    pageSize: 20,
+  });
+  const candidates = list.data.files ?? [];
+  if (candidates.length === 0) return null;
+  // Pick the candidate whose createdTime is closest to scheduledStart,
+  // and *only* when it falls within ±24h of the meeting. The window
+  // catches Gemini's normal 5–60min post-call generation plus some
+  // safety margin for re-generation events; rejecting outside the
+  // window prevents matching a doc from a same-title recurring
+  // meeting on a different day.
+  const MATCH_WINDOW_MS = 24 * 60 * 60_000;
+  const target = meeting.scheduledStart.getTime();
+  let best: { id: string; name: string } | null = null;
+  let bestDelta = Infinity;
+  for (const f of candidates) {
+    if (!f.id || !f.name) continue;
+    if (!f.createdTime) continue;
+    const created = new Date(f.createdTime).getTime();
+    const delta = Math.abs(created - target);
+    if (delta > MATCH_WINDOW_MS) continue;
+    if (delta < bestDelta) {
+      best = { id: f.id, name: f.name };
+      bestDelta = delta;
+    }
+  }
+  return best;
+}
+
+async function ensureSummaryNote(
+  meeting: { id: number; primaryDealId: number | null; primaryContactId: number | null; primaryCompanyId: number | null },
+  excerpt: string,
+  summaryDocUrl: string | null,
+): Promise<void> {
+  const owner = pickNoteOwner(meeting);
+  if (!owner) return; // No deal/contact/company to anchor the note to.
+
+  const existing = await prisma.note.findFirst({
+    where: { meetingId: meeting.id, source: 'meeting_summary' },
+    select: { id: true },
+  });
+  const content = summaryDocUrl
+    ? `${excerpt}\n\n[View full summary](${summaryDocUrl})`
+    : excerpt;
+  if (existing) {
+    await prisma.note.update({
+      where: { id: existing.id },
+      data: { content },
+    });
+    return;
+  }
+  await prisma.note.create({
+    data: {
+      content,
+      meetingId: meeting.id,
+      source: 'meeting_summary',
+      ...owner,
+    },
+  });
+}
+
+function pickNoteOwner(meeting: {
+  primaryDealId: number | null;
+  primaryContactId: number | null;
+  primaryCompanyId: number | null;
+}): { dealId: number } | { contactId: number } | { companyId: number } | null {
+  if (meeting.primaryDealId != null) return { dealId: meeting.primaryDealId };
+  if (meeting.primaryContactId != null) return { contactId: meeting.primaryContactId };
+  if (meeting.primaryCompanyId != null) return { companyId: meeting.primaryCompanyId };
+  return null;
+}
+
+async function materializeActionItems(
+  meeting: {
+    id: number;
+    primaryDealId: number | null;
+    organizerUserId: number | null;
+    scheduledEnd: Date;
+  },
+  items: ParsedActionItem[],
+): Promise<void> {
+  // 7 days is the spec default. Org-level overrides live on a future
+  // settings table — out of scope for v1.
+  const dueDate = new Date(meeting.scheduledEnd.getTime() + 7 * 86_400_000);
+
+  for (const item of items) {
+    // Skip items the parser stripped to nothing (e.g. a heading-only
+    // bullet, or a line whose owner-prefix matched but body was empty).
+    // A blank Task.title is just clutter in the pending-review queue.
+    if (!item.action.trim()) continue;
+    // Idempotency: skip if a Task with the same source text already
+    // exists for this meeting — handles Gemini regenerating the doc.
+    const existing = await prisma.task.findFirst({
+      where: {
+        sourceMeetingId: meeting.id,
+        sourceActionItemText: item.rawText,
+      },
+      select: { id: true },
+    });
+    if (existing) continue;
+
+    let assigneeUserId: number | null = null;
+    let customerCommitment = false;
+    if (item.ownerName) {
+      const matched = await matchUserByName(item.ownerName);
+      if (matched.length === 1) {
+        assigneeUserId = matched[0]!.id;
+      } else if (matched.length === 0) {
+        // No internal user matched — the action item is owned by the
+        // customer. Surface as customer_commitment so the deal page can
+        // separate "what we said we'd do" from "what they said they'd do".
+        customerCommitment = true;
+      }
+      // Multiple matches: leave assignee unset; the rep picks one in the
+      // pending_review UI.
+    } else if (meeting.organizerUserId) {
+      // Unowned action items default to the meeting organizer — they're
+      // the most likely committer in practice.
+      assigneeUserId = meeting.organizerUserId;
+    }
+
+    await prisma.task.create({
+      data: {
+        title: item.action,
+        status: 'pending_review',
+        dealId: meeting.primaryDealId,
+        assignedTo: assigneeUserId,
+        sourceMeetingId: meeting.id,
+        sourceActionItemText: item.rawText,
+        autoExtracted: true,
+        customerCommitment,
+        dueDate,
+      },
+    });
+  }
+}
+
+async function matchUserByName(rawName: string): Promise<{ id: number }[]> {
+  const name = rawName.trim();
+  if (!name) return [];
+  // Try full-name match first, then first-name fallback. We
+  // intentionally don't fuzzy-match across all users — the cost of a
+  // wrong assignee is "the rep has to reassign", but the cost of an
+  // ambiguous match in the matcher is "we put the wrong work in front
+  // of someone." Strict.
+  const full = await prisma.user.findMany({
+    where: { name: { equals: name, mode: 'insensitive' } },
+    select: { id: true },
+  });
+  if (full.length > 0) return full;
+  const first = name.split(/\s+/)[0];
+  if (!first || first === name) return [];
+  return prisma.user.findMany({
+    where: { name: { startsWith: `${first} `, mode: 'insensitive' } },
+    select: { id: true },
+  });
+}

--- a/apps/worker/src/jobs/googleCalendarPull.ts
+++ b/apps/worker/src/jobs/googleCalendarPull.ts
@@ -1,0 +1,588 @@
+import { DelayedError, type Job } from 'bullmq';
+import type {
+  GoogleCalendarPullJobData,
+  GoogleCalendarPullJobResult,
+} from '@pipelineflow/shared';
+import { prisma } from '../db.js';
+import { logger } from '../logger.js';
+import { redisConnection } from '../queue.js';
+import { acquireLock } from '../lib/redisLock.js';
+import { buildCalendarHandle } from '../integrations/google/calendarClient.js';
+import {
+  disableAccount,
+  GoogleAccountDisabledError,
+  isInvalidGrant,
+  loadGoogleAccount,
+  retryAfterMs,
+  statusCodeOf,
+} from '../integrations/google/peopleClient.js';
+import {
+  decideMatch,
+  domainOf,
+  type CompanyCandidate,
+  type ContactCandidate,
+  type DealCandidate,
+  type MatcherInputs,
+} from '../integrations/google/meetingMatcher.js';
+
+// Calendar pull job. One run per account per cron tick — the recurring
+// jobId pin in the api-side producer ensures we don't queue parallel
+// pulls for the same account.
+//
+// The job is idempotent: re-running with the same syncToken or a fresh
+// re-list of the lookback window simply re-upserts every event. Meeting
+// rows are keyed on `calendarEventId` (UNIQUE), so duplicate ingest
+// collapses to a noop.
+//
+// What "ingest" means here:
+//   1. List events (delta via syncToken, fall back to bounded re-list).
+//   2. Filter out events with no external attendees — internal-only
+//      meetings are noise, per spec.
+//   3. Upsert the Meeting row + replace its MeetingAttendee rows.
+//   4. If the Meeting is fresh (link_status = unlinked), run the matcher
+//      and persist the decision + audit row. If the Meeting already has
+//      a confirmed link, leave the linkage alone — re-running the
+//      matcher would surprise the rep.
+
+// 90-day lookback on the *first* run of an account (or after a manual
+// backfill that drops the sync token). Picks up the rep's recent
+// customer-facing history so the deal pages aren't suspiciously empty
+// for accounts that connected mid-quarter. Subsequent runs use Calendar's
+// `syncToken` and only see deltas, so the wide window is a one-time
+// cost. Looking forward 60d covers anything pre-staged by an SDR.
+const LOOKBACK_DAYS = 90;
+const TIME_LOOKAHEAD_DAYS = 60;
+
+export async function processGoogleCalendarPull(
+  job: Job<GoogleCalendarPullJobData, GoogleCalendarPullJobResult>,
+): Promise<GoogleCalendarPullJobResult> {
+  const log = logger.child({ jobId: job.id, jobName: job.name });
+  const { googleAccountId } = job.data;
+
+  // Per-account lock so a manual /resync triggered while a cron tick is
+  // in-flight doesn't double-process and race on the syncToken update.
+  const release = await acquireLock(
+    redisConnection,
+    `google-calendar-pull:lock:${googleAccountId}`,
+    6 * 60_000,
+  );
+  if (!release) {
+    log.info({ googleAccountId }, 'calendar pull: another run holds the lock, skipping');
+    return { upserted: 0, skipped: 0, matched: 0 };
+  }
+  try {
+    return await runPull(job, log);
+  } finally {
+    await release();
+  }
+}
+
+type ChildLogger = typeof logger;
+
+async function runPull(
+  job: Job<GoogleCalendarPullJobData, GoogleCalendarPullJobResult>,
+  log: ChildLogger,
+): Promise<GoogleCalendarPullJobResult> {
+  const { googleAccountId } = job.data;
+  const account = await loadGoogleAccount(googleAccountId);
+  if (!account) {
+    log.warn({ googleAccountId }, 'calendar pull: account not found');
+    return { upserted: 0, skipped: 0, matched: 0 };
+  }
+  if (account.disabledAt) {
+    log.info({ googleAccountId, reason: account.disabledReason }, 'calendar pull: account disabled');
+    return { upserted: 0, skipped: 0, matched: 0 };
+  }
+  const sync = await prisma.googleCalendarSync.findUnique({
+    where: { googleAccountId },
+  });
+  if (!sync || !sync.enabled) {
+    return { upserted: 0, skipped: 0, matched: 0 };
+  }
+
+  let handle;
+  try {
+    handle = await buildCalendarHandle(account);
+  } catch (err) {
+    if (err instanceof GoogleAccountDisabledError) {
+      return { upserted: 0, skipped: 0, matched: 0 };
+    }
+    throw err;
+  }
+  const { calendar } = handle;
+
+  // Internal-domain detection: default to the connected user's email
+  // domain. The spec calls this "configurable per workspace" — that's
+  // a P1; v1 uses the implicit-organizer-domain rule which works for
+  // every setup we'd realistically demo against.
+  const internalDomains = new Set<string>();
+  const ownDomain = domainOf(account.googleEmail);
+  if (ownDomain) internalDomains.add(ownDomain);
+
+  let upserted = 0;
+  let skipped = 0;
+  let matched = 0;
+
+  let syncToken: string | null = sync.eventsSyncToken;
+  let pageToken: string | undefined;
+  let nextSyncToken: string | undefined;
+  // Cap pages to avoid holding a worker slot indefinitely.
+  const MAX_PAGES = 25;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    let response;
+    try {
+      const params: import('googleapis').calendar_v3.Params$Resource$Events$List = {
+        calendarId: 'primary',
+        // showDeleted=true: we want to mark deleted meetings cancelled
+        // rather than silently leaving stale rows on the deal timeline.
+        showDeleted: true,
+        // singleEvents=true: expand recurring series into individual
+        // instances. Handling recurrence in the matcher is more complex
+        // than it's worth — every customer call is a discrete row.
+        singleEvents: true,
+        maxResults: 100,
+      };
+      if (pageToken) params.pageToken = pageToken;
+      if (syncToken) {
+        params.syncToken = syncToken;
+      } else {
+        // No delta token — bounded re-list. Lookback covers anything
+        // that happened during a brief disconnect; lookahead lets us
+        // pre-stage meetings the rep is about to take.
+        const now = Date.now();
+        params.timeMin = new Date(now - LOOKBACK_DAYS * 86_400_000).toISOString();
+        params.timeMax = new Date(now + TIME_LOOKAHEAD_DAYS * 86_400_000).toISOString();
+        // orderBy is illegal with a syncToken; only set it when we're
+        // doing the windowed re-list.
+        params.orderBy = 'startTime';
+      }
+      response = await calendar.events.list(params);
+    } catch (err) {
+      if (isInvalidGrant(err)) {
+        await disableAccount(googleAccountId, 'invalid_grant');
+        return { upserted, skipped, matched };
+      }
+      const status = statusCodeOf(err);
+      if (status === 410 && syncToken) {
+        log.info({ googleAccountId }, 'calendar syncToken expired, re-listing window');
+        syncToken = null;
+        pageToken = undefined;
+        continue;
+      }
+      if (status === 429) {
+        const ts = Date.now() + retryAfterMs(err);
+        await job.moveToDelayed(ts, job.token);
+        throw new DelayedError();
+      }
+      throw err;
+    }
+
+    const events = response.data.items ?? [];
+    for (const ev of events) {
+      try {
+        const result = await ingestEvent(googleAccountId, internalDomains, ev);
+        if (result === 'upserted') upserted++;
+        else if (result === 'matched') {
+          upserted++;
+          matched++;
+        } else skipped++;
+      } catch (err) {
+        log.warn(
+          { err, eventId: ev.id, googleAccountId },
+          'failed to ingest calendar event, continuing',
+        );
+        skipped++;
+      }
+    }
+
+    if (response.data.nextSyncToken) {
+      nextSyncToken = response.data.nextSyncToken;
+    }
+    pageToken = response.data.nextPageToken ?? undefined;
+    syncToken = null; // sync token only valid on first page
+    if (!pageToken) break;
+  }
+
+  await prisma.googleCalendarSync.update({
+    where: { googleAccountId },
+    data: {
+      lastEventsSyncedAt: new Date(),
+      ...(nextSyncToken ? { eventsSyncToken: nextSyncToken } : {}),
+    },
+  });
+
+  log.info(
+    { googleAccountId, upserted, skipped, matched },
+    'calendar pull complete',
+  );
+  return { upserted, skipped, matched };
+}
+
+type IngestOutcome = 'upserted' | 'matched' | 'skipped';
+
+async function ingestEvent(
+  googleAccountId: number,
+  internalDomains: Set<string>,
+  ev: import('googleapis').calendar_v3.Schema$Event,
+): Promise<IngestOutcome> {
+  if (!ev.id) return 'skipped';
+
+  // Cancelled events: mark the local row cancelled if present, otherwise
+  // ignore (no point creating a Meeting row only to immediately cancel).
+  if (ev.status === 'cancelled') {
+    await prisma.meeting.updateMany({
+      where: { calendarEventId: ev.id },
+      data: { status: 'cancelled' },
+    });
+    return 'upserted';
+  }
+
+  // Skip events without enough information to be a real meeting.
+  if (!ev.summary || !ev.start || !ev.end) return 'skipped';
+
+  // Pull external + internal attendees apart. External = not on an
+  // internal domain and not the organizer's own address. Honor the
+  // [no-crm] opt-out marker per spec — descriptions matching it are
+  // dropped entirely.
+  const description = ev.description ?? '';
+  if (/\[no-crm\]/i.test(description)) return 'skipped';
+
+  const attendees = ev.attendees ?? [];
+  const externalAttendeeEmails: string[] = [];
+  const allAttendeeRows: Array<{
+    email: string;
+    name: string | null;
+    responseStatus: string | null;
+    isOrganizer: boolean;
+  }> = [];
+  for (const a of attendees) {
+    if (!a.email) continue;
+    const email = a.email.toLowerCase().trim();
+    const dom = domainOf(email);
+    const isInternal = dom ? internalDomains.has(dom) : false;
+    allAttendeeRows.push({
+      email,
+      name: a.displayName ?? null,
+      responseStatus: a.responseStatus ?? null,
+      isOrganizer: Boolean(a.organizer),
+    });
+    if (!isInternal) externalAttendeeEmails.push(email);
+  }
+
+  // Skip internal-only meetings — they're noise on the deal timeline.
+  if (externalAttendeeEmails.length === 0) return 'skipped';
+
+  // Resolve scheduled times. Calendar can report dateTime (timed events)
+  // or date (all-day) — we ignore all-day events; they're not real
+  // meetings worth tracking on the deal timeline.
+  if (!ev.start.dateTime || !ev.end.dateTime) return 'skipped';
+  const scheduledStart = new Date(ev.start.dateTime);
+  const scheduledEnd = new Date(ev.end.dateTime);
+
+  // Resolve organizer to internal user when possible. Calendar's
+  // `organizer.self` is unreliable for shared / delegated events; we
+  // match on email instead. If neither the event nor the attendee
+  // list yields an organizer email, skip — `Meeting.organizerEmail` is
+  // non-null in the schema and an empty string carries no meaning.
+  const eventOrganizer = (ev.organizer?.email ?? '').toLowerCase();
+  const attendeeOrganizer = attendees
+    .find((a) => a.organizer && a.email)
+    ?.email?.toLowerCase() ?? '';
+  const organizerEmail = eventOrganizer || attendeeOrganizer;
+  if (!organizerEmail) return 'skipped';
+  const organizerUser = await prisma.user.findUnique({
+    where: { email: organizerEmail },
+    select: { id: true },
+  });
+
+  const conferenceId = pickConferenceId(ev);
+  const status = computeStatus(scheduledStart, scheduledEnd);
+
+  // Pre-resolve attendee → Contact / User outside the transaction. Two
+  // batched findMany calls, then a Map lookup per attendee, instead of
+  // an N×2 query loop while holding the transaction open. Keeps the
+  // transaction tight and stops a single calendar event from pinning a
+  // DB connection through ten round-trips.
+  const externalEmails = allAttendeeRows
+    .filter((a) => {
+      const dom = domainOf(a.email);
+      return !(dom && internalDomains.has(dom));
+    })
+    .map((a) => a.email);
+  const internalEmails = allAttendeeRows
+    .filter((a) => {
+      const dom = domainOf(a.email);
+      return dom != null && internalDomains.has(dom);
+    })
+    .map((a) => a.email);
+
+  const [contactRows, userRows] = await Promise.all([
+    externalEmails.length === 0
+      ? Promise.resolve<Array<{ id: number; email: string | null }>>([])
+      : prisma.contact.findMany({
+          where: { email: { in: externalEmails, mode: 'insensitive' } },
+          select: { id: true, email: true },
+        }),
+    internalEmails.length === 0
+      ? Promise.resolve<Array<{ id: number; email: string }>>([])
+      : prisma.user.findMany({
+          where: { email: { in: internalEmails } },
+          select: { id: true, email: true },
+        }),
+  ]);
+  // Lowercased keys so the lookup is case-insensitive across whatever
+  // case the Calendar event used vs. how the address was stored.
+  const contactByEmail = new Map<string, number>();
+  for (const c of contactRows) {
+    if (c.email) contactByEmail.set(c.email.toLowerCase(), c.id);
+  }
+  const userByEmail = new Map<string, number>();
+  for (const u of userRows) userByEmail.set(u.email.toLowerCase(), u.id);
+
+  const upserted = await prisma.$transaction(async (tx) => {
+    // Upsert the Meeting row. We deliberately do NOT touch the link_*
+    // fields here — those are the matcher's domain. The first-time
+    // create starts at link_status='unlinked'; subsequent updates leave
+    // any existing linkage alone.
+    const existing = await tx.meeting.findUnique({
+      where: { calendarEventId: ev.id! },
+      select: { id: true, linkStatus: true },
+    });
+
+    const baseFields = {
+      calendarEventId: ev.id!,
+      calendarProvider: 'google',
+      sourceAccountId: googleAccountId,
+      conferenceId,
+      organizerEmail,
+      organizerUserId: organizerUser?.id ?? null,
+      title: ev.summary!,
+      description: description || null,
+      scheduledStart,
+      scheduledEnd,
+      status,
+    } as const;
+
+    let meetingId: number;
+    if (existing) {
+      const updated = await tx.meeting.update({
+        where: { id: existing.id },
+        data: baseFields,
+      });
+      meetingId = updated.id;
+    } else {
+      const created = await tx.meeting.create({
+        data: baseFields,
+      });
+      meetingId = created.id;
+    }
+
+    // Replace attendee rows. Cheap on the index, and Calendar can swap
+    // out attendees mid-flight (rep moves the meeting to a different
+    // contact); upsert-by-(meetingId,email) would also work but a clean
+    // diff-replace keeps the row count tight. Lookups come from the
+    // pre-resolved Maps above so this loop stays inside the transaction
+    // without per-row queries.
+    await tx.meetingAttendee.deleteMany({ where: { meetingId } });
+    if (allAttendeeRows.length > 0) {
+      await tx.meetingAttendee.createMany({
+        data: allAttendeeRows.map((a) => {
+          const dom = domainOf(a.email);
+          const isInternal = dom ? internalDomains.has(dom) : false;
+          return {
+            meetingId,
+            email: a.email,
+            name: a.name,
+            contactId: isInternal ? null : contactByEmail.get(a.email) ?? null,
+            userId: isInternal ? userByEmail.get(a.email) ?? null : null,
+            responseStatus: a.responseStatus,
+            isOrganizer: a.isOrganizer,
+          };
+        }),
+      });
+    }
+
+    // Lock the matcher out for any user-driven terminal state. 'confirmed'
+    // means the rep signed off; 'rejected' means the rep explicitly said
+    // "this isn't the right deal." Re-running the matcher in either case
+    // would silently undo their action on the next cron tick.
+    const locked =
+      existing?.linkStatus === 'confirmed' || existing?.linkStatus === 'rejected';
+    return { meetingId, locked };
+  });
+
+  if (upserted.locked) {
+    return 'upserted';
+  }
+
+  // Run the matcher. Caller hands in already-loaded candidates so the
+  // matcher itself stays Prisma-free and unit-testable.
+  const matcherInput = await loadMatcherInputs(externalAttendeeEmails, ev.summary!);
+  const decision = decideMatch(matcherInput);
+
+  await persistMatchDecision(upserted.meetingId, decision);
+  return decision.outcome === 'unlinked' ? 'upserted' : 'matched';
+}
+
+// Pull the conferenceRecord name out of a Calendar event. Meet writes
+// the record id into conferenceData.entryPoints[].uri — we pluck the
+// space identifier off the meet.google.com URL and convert it to the
+// `conferenceRecords/...` format the Meet API consumes. The space id is
+// stable across re-joins of the same conference.
+function pickConferenceId(ev: import('googleapis').calendar_v3.Schema$Event): string | null {
+  const data = ev.conferenceData;
+  if (!data) return null;
+  // Prefer the conferenceId attribute when present — it's the stable
+  // space id and exactly what we need.
+  if (data.conferenceId) return data.conferenceId;
+  // Fall back to parsing the entryPoint URI.
+  const ep = data.entryPoints?.find((e) => e.entryPointType === 'video' && e.uri);
+  if (!ep?.uri) return null;
+  const m = /meet\.google\.com\/([a-z0-9-]+)/i.exec(ep.uri);
+  return m ? m[1] ?? null : null;
+}
+
+function computeStatus(scheduledStart: Date, scheduledEnd: Date): string {
+  const now = Date.now();
+  if (now < scheduledStart.getTime()) return 'scheduled';
+  if (now < scheduledEnd.getTime()) return 'in_progress';
+  return 'completed';
+}
+
+async function loadMatcherInputs(
+  externalAttendeeEmails: string[],
+  eventTitle: string,
+): Promise<MatcherInputs> {
+  const contacts = await prisma.contact.findMany({
+    where: {
+      email: { in: externalAttendeeEmails, mode: 'insensitive' },
+    },
+    select: { id: true, email: true, companyId: true },
+  });
+
+  const contactsByAttendee: ContactCandidate[] = contacts.map((c) => ({
+    id: c.id,
+    email: c.email,
+    companyId: c.companyId,
+  }));
+
+  // Open deals: anything not on a won/lost stage. The seed and migrations
+  // mark won/lost via PipelineStage.isWon / isLost, so the cleanest read
+  // is "stage is not isWon and not isLost". A deal can land on the
+  // matcher via either contact or company linkage.
+  const contactIds = contacts.map((c) => c.id);
+  const companyIds = uniqueNumbers(contacts.map((c) => c.companyId).filter((v): v is number => v != null));
+
+  const openDeals = contactIds.length === 0 && companyIds.length === 0
+    ? []
+    : await prisma.deal.findMany({
+        where: {
+          AND: [
+            { stage: { isWon: false, isLost: false } },
+            {
+              OR: [
+                { primaryContactId: { in: contactIds } },
+                { companyId: { in: companyIds } },
+              ],
+            },
+          ],
+        },
+        select: { id: true, title: true, primaryContactId: true, companyId: true },
+      });
+
+  const openDealsByContact = new Map<number, DealCandidate[]>();
+  for (const d of openDeals) {
+    // Deals attach via primary contact OR company. For matcher purposes
+    // we attribute to every contact that could plausibly own it: the
+    // primary contact directly, plus any matched contact whose company
+    // matches the deal's company.
+    const owners = new Set<number>();
+    if (d.primaryContactId != null) owners.add(d.primaryContactId);
+    for (const c of contacts) {
+      if (c.companyId != null && c.companyId === d.companyId) owners.add(c.id);
+    }
+    for (const ownerId of owners) {
+      const list = openDealsByContact.get(ownerId) ?? [];
+      list.push({
+        id: d.id,
+        title: d.title,
+        primaryContactId: d.primaryContactId,
+        companyId: d.companyId,
+      });
+      openDealsByContact.set(ownerId, list);
+    }
+  }
+
+  // Domain-match candidates. Build the domain set from the attendees;
+  // any company whose `domains[]` contains any of those is a candidate.
+  const domains = uniqueStrings(
+    externalAttendeeEmails.map(domainOf).filter((d): d is string => Boolean(d)),
+  );
+  const companies = domains.length === 0
+    ? []
+    : await prisma.company.findMany({
+        where: { domains: { hasSome: domains } },
+        select: { id: true, domains: true },
+      });
+  const companiesByDomain: CompanyCandidate[] = companies.map((c) => ({
+    id: c.id,
+    domains: c.domains.map((d) => d.toLowerCase()),
+  }));
+
+  return {
+    externalAttendeeEmails,
+    eventTitle,
+    contactsByAttendee,
+    openDealsByContact,
+    companiesByDomain,
+  };
+}
+
+async function persistMatchDecision(
+  meetingId: number,
+  decision: ReturnType<typeof decideMatch>,
+): Promise<void> {
+  await prisma.$transaction(async (tx) => {
+    const linkStatus =
+      decision.outcome === 'auto_confirmed'
+        ? 'confirmed'
+        : decision.outcome === 'suggested'
+        ? 'suggested'
+        : 'unlinked';
+
+    await tx.meeting.update({
+      where: { id: meetingId },
+      data: {
+        primaryContactId: decision.primaryContactId,
+        primaryDealId: decision.primaryDealId,
+        primaryCompanyId: decision.primaryCompanyId,
+        linkStatus,
+        // Decimal columns accept number or string; we hand a number so the
+        // round-trip preserves the matcher's confidence value.
+        linkConfidence: decision.confidence > 0 ? decision.confidence : null,
+        linkMethod: decision.method,
+        linkedAt: linkStatus === 'confirmed' ? new Date() : null,
+      },
+    });
+
+    await tx.meetingLinkAudit.create({
+      data: {
+        meetingId,
+        method: decision.method ?? 'email_match',
+        candidates: decision.candidates as unknown as object,
+        chosenContactId: decision.primaryContactId,
+        chosenDealId: decision.primaryDealId,
+        chosenCompanyId: decision.primaryCompanyId,
+        confidence: decision.confidence > 0 ? decision.confidence : null,
+        outcome: 'accepted',
+      },
+    });
+  });
+}
+
+function uniqueNumbers(arr: number[]): number[] {
+  return Array.from(new Set(arr));
+}
+function uniqueStrings(arr: string[]): string[] {
+  return Array.from(new Set(arr));
+}

--- a/packages/shared/src/queues.ts
+++ b/packages/shared/src/queues.ts
@@ -131,6 +131,52 @@ export type ScheduledBackupJobResult = {
   durationMs: number;
 };
 
+// ─── Google Calendar sync queues ────────────────────────────────────────────
+// Two queues split along the same axis as the integration's two loops:
+//   - calendar-pull: list events from Google Calendar, upsert Meeting rows,
+//     run the auto-link matcher. Scheduled (every 5 minutes per account)
+//     plus on-connect one-shot.
+//   - calendar-artifacts: for completed meetings without all artifacts,
+//     poll Meet recordings/transcripts and search Drive for the Gemini
+//     summary doc. Runs on a slower cadence and gives up after the
+//     6-hour cap defined in spec-artifact-attach.md.
+// Job data deliberately keys on `googleAccountId` only — the worker
+// re-queries Postgres on each run so an in-flight job picks up the
+// freshest state (e.g. an event the rep just rescheduled).
+export const QUEUE_GOOGLE_CALENDAR_PULL = 'google-calendar-pull' as const;
+export const QUEUE_GOOGLE_CALENDAR_ARTIFACTS = 'google-calendar-artifacts' as const;
+
+export type GoogleCalendarPullJobData =
+  // Single mode for v1 — incremental delta with bounded re-list fallback.
+  // Initial bulk-backfill is a P1 from the spec; we re-list a small
+  // lookback window the first run instead of paginating the user's
+  // entire calendar history.
+  | { kind: 'incremental'; googleAccountId: number };
+
+export type GoogleCalendarPullJobResult = {
+  upserted: number;
+  skipped: number;
+  // The matcher ran on this many newly-ingested or changed meetings.
+  matched: number;
+};
+
+export type GoogleCalendarArtifactsJobData = {
+  // No mode here — the worker scans the full backlog of completed meetings
+  // for this account and processes whatever's missing. Cheaper than
+  // surgically queueing one job per meeting.
+  googleAccountId: number;
+};
+
+export type GoogleCalendarArtifactsJobResult = {
+  // Meetings the watcher touched on this run.
+  considered: number;
+  // Meetings where at least one artifact URL was newly populated.
+  attached: number;
+  // Meetings flagged partial (gave up after the 6h cap with at least one
+  // artifact still missing).
+  partial: number;
+};
+
 // ─── Enrichment queue ───────────────────────────────────────────────────────
 // One job per company-enrichment attempt. The job re-reads the Company row
 // each run so the latest record (post any in-flight edits) is what gets


### PR DESCRIPTION
- Implemented `googleCalendarArtifacts.ts` to handle fetching and processing meeting artifacts from Google Calendar, including recordings, transcripts, and summary documents.
- Introduced `googleCalendarPull.ts` for syncing calendar events, filtering out internal meetings, and upserting meeting data into the database.
- Added logic for handling meeting attendees, linking contacts and deals, and managing event statuses.
- Ensured idempotency in both jobs to prevent duplicate processing and maintain data integrity.
